### PR TITLE
Add mutation testing workflow and refine task/test guidelines

### DIFF
--- a/.claude/skills/slice/SKILL.md
+++ b/.claude/skills/slice/SKILL.md
@@ -5,12 +5,17 @@ description: Execute the next vertical slice from handoff.md — confirms the ta
 
 # Next Slice Workflow
 
-1. Read docs/handoff.md — identify the FIRST uncompleted task
-2. Confirm the exact task with the user BEFORE writing any code
-3. Write failing tests first that define the expected behaviour
+1. Read `docs/handoff.md` — identify the FIRST uncompleted task
+2. Confirm the exact task with the user BEFORE writing any code. If the task has no acceptance criteria, draft them with the user before proceeding.
+3. **Write failing tests first.** For each test:
+   - State in the `it`/`describe` label what specific behaviour is being specified
+   - Ask: "What would have to be wrong in the implementation for this test to still pass?" Add at least one assertion that answers that — pin exact values, boundary conditions, or the absence of something
+   - A test that only verifies a result exists is incomplete — assert the shape, a boundary case, and at least one error/edge path
+   - Before moving to implementation: review the test file as a whole. Would a logic inversion (`>` → `>=`, `+` → `-`, a null guard flipped) survive undetected? If yes, add a test that would catch it.
 4. Implement the minimum code to make each test pass, one at a time
-5. Run `pnpm check` (this runs biome check + build + test all together) — all must pass before continuing
-6. Remove the completed slice from docs/handoff.md and update the "Current state" section (test count, layout changes)
-7. Update docs/agent-memory.md with any architectural decisions made
-8. Commit with a conventional commit message
-9. Do NOT proceed to the next slice without explicit user approval
+5. Run `pnpm check` (biome check + build + test) — all must pass before continuing
+6. Run `pnpm test:mutate` scoped to the files changed in this slice. If the score is below threshold, add tests — do not adjust the threshold or add survivors to `docs/quality.md` without explaining why the gap is accepted.
+7. Remove the completed slice from `docs/handoff.md` and update the "Current state" section (test count, layout changes). Update any affected feature docs.
+8. Update `docs/agent-memory.md` with any architectural decisions or non-obvious gotchas discovered
+9. Commit with a conventional commit message (see `CLAUDE.md`)
+10. Do NOT proceed to the next slice without explicit user approval

--- a/.github/workflows/quality-feedback.yml
+++ b/.github/workflows/quality-feedback.yml
@@ -1,0 +1,48 @@
+name: Quality Feedback
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  mutation:
+    name: Mutation Testing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - name: Run mutation tests
+        id: mutate
+        run: pnpm test:mutate
+        continue-on-error: true
+
+      - name: Upload mutation report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mutation-report
+          path: reports/mutation/mutation.html
+
+      - name: Post summary
+        if: always()
+        run: |
+          if [ "${{ steps.mutate.outcome }}" == "success" ]; then
+            echo "## Mutation score: above threshold" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## Mutation score: below threshold ⚠️" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Full report: download the \`mutation-report\` artifact." >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Flag ambiguity early. The cost of asking is zero compared to building on a wrong
 Explicitly state the version and instruct the subagent to confirm it from `package.json` inside the package directory before reading any source.
 
 **Rule 5: Write tests as you implement, not after.**
-Finish the test for a unit before moving to the next. The test is part of the implementation.
+Finish the test for a unit before moving to the next. The test is part of the implementation. Tests must specify behaviour, not just verify it: pin exact output shapes, cover at least one boundary or error path, and ask "what logic inversion would this test still pass through?" before moving on. TypeScript's type system does not kill mutants — only assertions do.
 
 **Rule 6: When fixing items from tech-debt.md, remove them from the doc in the same commit. Only touch entries you actually completed.**
 
@@ -50,6 +50,9 @@ This project runs in a dev container. The home directory is deleted on every reb
 - `docs/agent-memory.md` — technical gotchas and decisions useful to humans too (git-tracked)
 
 Update both at the end of every session.
+
+**Rule 10: ACs are required before implementation, not before backlog entry.**
+Tasks in `docs/handoff.md` are either `[needs design]` (problem known, solution not yet agreed) or ready (has acceptance criteria). When adding new work discovered during a session, add a `[needs design]` entry and move on — do not design it in the same session. When picking up a `[needs design]` task, the first move is to propose ACs to the user; do not write code until they are agreed. Do not add ACs to feature docs (`docs/features/*.md`) — those are reference specs, not task tracking. ACs belong to the task entry and are deleted when the task ships.
 
 **Rule 9: Dogfood the tools — you are the target user.**
 The `mcp__light-bridge__*` tools are always available (configured in `.mcp.json`; daemon auto-spawns on first use). Every user of this tool gets the same MCP tool descriptions you do. If those descriptions aren't compelling enough to make you reach for the tools naturally during development, they aren't good enough for users either — improve the description, don't add a private agent rule. Shareable skills (`.claude/skills/`) are fine — they ship with the tool and any consumer can load them. Private memories and rules that only exist in this repo's config are not a substitute for good descriptions. If a tool can't do what you need at all, add it to `docs/handoff.md`.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -118,6 +118,9 @@ Acceptance criteria:
 - scope is explicitly approved by the owner before implementation work starts
 - the first implementation task in handoff references that approved scope doc instead of assuming a fixed eval architecture
 
+**12. Agent triage on mutation score warning** `[needs design]`
+When the Quality Feedback workflow warns (score below threshold), trigger a Claude Code agent run to inspect surviving mutants and either open a GitHub issue summarising gaps or attempt a fix branch. Key design questions: report-only vs auto-fix, what artifact the agent receives (HTML report, JSON report, or inline Stryker run), and guardrails on which files it can touch. Uses `claude-code-action` in a second job conditioned on the mutation step outcome.
+
 ---
 
 ### P3 — High-value features

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -18,7 +18,11 @@ Context that isn't in the feature docs — things you need to know before pickin
 4. [`docs/architecture.md`](architecture.md) — provider/operation architecture; read before touching anything in `src/`
 5. [`docs/quality.md`](quality.md) — testing and reliability expectations
 
-**Picking up a task?** Each item in "Next things to build" links to its feature doc. The feature doc is the detailed spec — start there, then come back to the task entry for the implementation notes that aren't in the doc. If no feature doc is linked, writing the design doc is the first step.
+**Picking up a task?** Tasks are at one of two levels:
+- **`[needs design]`** — the problem is understood but the solution isn't. First move: propose a design and acceptance criteria to the user. Do not write code until ACs are agreed.
+- **No tag** — has acceptance criteria, ready to implement. Read the linked feature doc, then use the task entry for implementation notes not in the doc.
+
+An agent discovering new work should add a `[needs design]` entry and move on — do not block on designing it in the same session.
 
 **Finishing a task?** Before committing, verify:
 1. Remove the task from the backlog below (or move to P5 if accepted/deferred)
@@ -118,16 +122,15 @@ Acceptance criteria:
 
 ### P3 — High-value features
 
-**9. `findReferences` by file path**
+**9. `findReferences` by file path** `[needs design]`
 Feature doc: [`features/findReferences.md`](features/findReferences.md) — covers the symbol-position variant; the file-path variant needs a design section added.
 "Who imports this file?" is a different question from "who uses this symbol?". Options: union references across all exports (expensive), use `getEditsForFileRename` as a dry-run proxy (already available from `moveFile`), or scan import strings with the compiler's module resolver. Worth a separate design pass — keep separate from the symbol-position variant.
 
-**9. `moveSymbol` for class methods**
+**9. `moveSymbol` for class methods** `[needs design]`
 Feature doc: [`features/moveSymbol.md`](features/moveSymbol.md) — covers the current top-level-export behaviour; class method extraction needs a design section added.
 Currently only top-level exported declarations are supported. "Extract this method to a standalone exported function in another module" is one of the most common refactoring patterns agents perform. The extraction involves removing the method from the class, writing a standalone `export function` at the destination, rewriting all call sites from `instance.method(args)` to `method(instance, args)` or `method(args)` depending on whether `this` is used. The ts-morph AST has everything needed: `MethodDeclaration`, `CallExpression`, `this` references. Discovered during Phase 2 dogfooding — `BaseEngine` methods couldn't be extracted with `moveSymbol` because they were class methods, not top-level exports.
 
-**10. `deleteFile`**
-Feature doc: none yet — write the design doc as the first step.
+**10. `deleteFile`** `[needs design]`
 Remove a file and clean up its imports in referencing files. Simpler than `createFile` (no scaffolding logic); the compiler already knows all importers via `getEditsForFileRename`.
 
 ---
@@ -142,12 +145,10 @@ Feature docs: [`architecture.md`](architecture.md), [`tech/volar-v3.md`](tech/vo
 Feature doc: [`features/moveSymbol.md`](features/moveSymbol.md)
 Moving a top-level export *from* a `.ts` file in a Vue project is complete — ts-morph handles `.ts` importers; `VolarProvider.afterSymbolMove` patches `.vue` SFC importers. The remaining case is a symbol declared *inside* a `.vue` `<script setup>` block: use `@vue/compiler-sfc`'s `parse()` to locate and splice the `<script>` block (`@vue/language-core` re-exports it; already a transitive dep). Moving *into* a `.vue` destination is not worth supporting. Depends on #11.
 
-**13. `createFile`**
-Feature doc: none yet — write the design doc as the first step.
+**13. `createFile`** `[needs design]`
 Scaffold a file with correct import paths inferred from its location.
 
-**14. `extractFunction`**
-Feature doc: none yet — write the design doc as the first step.
+**14. `extractFunction`** `[needs design]`
 Pull a selection into a named function, updating the call site. High potential value but AST-level code generation is complex across all call-site shapes; wait until P1–P3 are stable.
 
 **15. Claude Code plugin distribution**


### PR DESCRIPTION
## Summary
This PR introduces automated mutation testing to the quality feedback pipeline and clarifies task management and test-writing practices across the codebase.

## Key Changes

**Mutation Testing Workflow**
- Added `.github/workflows/quality-feedback.yml` to run mutation tests on every push to main
- Uploads mutation report as a GitHub artifact for inspection
- Posts summary to workflow run with threshold status
- Lays groundwork for future agent-driven triage of surviving mutants (task #12)

**Task Management Clarification** (`docs/handoff.md`)
- Introduced `[needs design]` tag to distinguish tasks needing design approval from ready-to-implement tasks
- Clarified that agents discovering new work should add `[needs design]` entries without blocking on design in the same session
- Applied tag to existing backlog items (#9, #10, #12, #13, #14) that lack acceptance criteria
- Added task #12: Agent triage on mutation score warnings (design phase)

**Test-Writing Standards** (`.claude/skills/slice/SKILL.md` and `CLAUDE.md`)
- Expanded test guidance to emphasize *specifying* behaviour, not just verifying it
- Added concrete checks: pin exact values, cover boundary conditions, test error paths
- Introduced mutation-resistance check: "What logic inversion would this test still pass through?"
- Added step 6 to slice workflow: run scoped mutation tests and add tests if score is below threshold
- Clarified that mutation testing is part of the definition of done

**Agent Rules** (`CLAUDE.md`)
- Added Rule 10: ACs required before implementation, not before backlog entry
- Clarified distinction between `[needs design]` tasks (propose ACs first) and ready tasks (implement directly)
- Reinforced that ACs belong in task entries, not feature docs, and are deleted when task ships

## Implementation Details
- Mutation workflow uses `pnpm test:mutate` (assumed to exist in package.json scripts)
- Artifact path `reports/mutation/mutation.html` matches expected Stryker output structure
- Workflow continues on error to ensure report upload and summary posting always run
- Task #12 is marked `[needs design]` because key decisions (report-only vs auto-fix, artifact format, guardrails) are still open

https://claude.ai/code/session_01PX5dHoyea5Mx5KfSsgAnDW