### PR TITLE
Reprioritize roadmap: promote getTypeErrors to P3, add extractFunction

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -135,20 +135,26 @@ Acceptance criteria:
 - `README.md` tool table updated, `docs/features/getTypeErrors.md` created
 - Tests cover: single-file errors, project-wide with cap, post-write diagnostics on rename, clean file returns empty array
 
-**9. `findReferences` by file path** `[needs design]`
-Feature doc: [`features/findReferences.md`](features/findReferences.md) — covers the symbol-position variant; the file-path variant needs a design section added.
-"Who imports this file?" is a different question from "who uses this symbol?". Options: union references across all exports (expensive), use `getEditsForFileRename` as a dry-run proxy (already available from `moveFile`), or scan import strings with the compiler's module resolver. Worth a separate design pass — keep separate from the symbol-position variant.
-
 **9. `moveSymbol` for class methods** `[needs design]`
 Feature doc: [`features/moveSymbol.md`](features/moveSymbol.md) — covers the current top-level-export behaviour; class method extraction needs a design section added.
 Currently only top-level exported declarations are supported. "Extract this method to a standalone exported function in another module" is one of the most common refactoring patterns agents perform. The extraction involves removing the method from the class, writing a standalone `export function` at the destination, rewriting all call sites from `instance.method(args)` to `method(instance, args)` or `method(args)` depending on whether `this` is used. The ts-morph AST has everything needed: `MethodDeclaration`, `CallExpression`, `this` references. Discovered during Phase 2 dogfooding — `BaseEngine` methods couldn't be extracted with `moveSymbol` because they were class methods, not top-level exports.
 
-**10. `deleteFile`** `[needs design]`
+**10. `extractFunction`** `[needs design]`
+Pull a selection into a named function, updating the call site. Agents extract functions constantly — this is one of the most common refactoring patterns alongside method extraction (#9). AST-level code generation is complex across all call-site shapes.
+
+**17. `deleteFile`** `[needs design]`
 Remove a file and clean up its imports in referencing files. Simpler than `createFile` (no scaffolding logic); the compiler already knows all importers via `getEditsForFileRename`.
 
 ---
 
 ### P4 — Medium-value features and tech debt
+
+**18. `findReferences` by file path** `[needs design]`
+Feature doc: [`features/findReferences.md`](features/findReferences.md) — covers the symbol-position variant; the file-path variant needs a design section added.
+"Who imports this file?" is a different question from "who uses this symbol?". Options: union references across all exports (expensive), use `getEditsForFileRename` as a dry-run proxy (already available from `moveFile`), or scan import strings with the compiler's module resolver. Worth a separate design pass — keep separate from the symbol-position variant. Workable approximation exists today via `searchText` for the import path.
+
+**16. `getTypeErrors` Volar support for `.vue` files** `[needs design]`
+Extend type error detection to `.vue` SFC `<script>` blocks via VolarProvider. Requires the same virtual-to-real path translation used by `findReferences` and `getDefinition` in Volar. Depends on P3 item 8 (TS-only `getTypeErrors`) shipping first. Design questions: whether to use `@volar/typescript` proxy's `getSemanticDiagnostics` or Volar's own diagnostic API, and how to map virtual-file positions back to SFC line numbers.
 
 **11. `buildVolarService` refactoring**
 Feature docs: [`architecture.md`](architecture.md), [`tech/volar-v3.md`](tech/volar-v3.md)
@@ -160,12 +166,6 @@ Moving a top-level export *from* a `.ts` file in a Vue project is complete — t
 
 **13. `createFile`** `[needs design]`
 Scaffold a file with correct import paths inferred from its location.
-
-**14. `extractFunction`** `[needs design]`
-Pull a selection into a named function, updating the call site. High potential value but AST-level code generation is complex across all call-site shapes; wait until P1–P3 are stable.
-
-**16. `getTypeErrors` Volar support for `.vue` files** `[needs design]`
-Extend type error detection to `.vue` SFC `<script>` blocks via VolarProvider. Requires the same virtual-to-real path translation used by `findReferences` and `getDefinition` in Volar. Depends on P3 item 8 (TS-only `getTypeErrors`) shipping first. Design questions: whether to use `@volar/typescript` proxy's `getSemanticDiagnostics` or Volar's own diagnostic API, and how to map virtual-file positions back to SFC line numbers.
 
 **15. Claude Code plugin distribution**
 Feature docs: [`architecture.md`](architecture.md), [`features/daemon.md`](features/daemon.md)

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -111,6 +111,30 @@ When the Quality Feedback workflow warns (score below threshold), trigger a Clau
 
 ### P3 — High-value features
 
+**8. `getTypeErrors` — standalone tool + post-write diagnostics**
+
+Two parts:
+1. **Standalone `getTypeErrors` MCP tool** — check a specific file or the whole project for type errors. Optional `file` param (absolute path); if omitted, checks all project files. Returns `{ diagnostics: [{ file, line, col, code, message }], errorCount, truncated }`. Errors only (no warnings). Cap at 100 results.
+2. **Post-write type diagnostics** — after every write operation (rename, moveFile, moveSymbol, replaceText), refresh modified files in the provider cache and check them for type errors. Append `typeErrors` array to the result. Cap at 20.
+
+Both use the same diagnostic extraction logic via TsProvider. TS/TSX files only (Vue `.vue` SFC diagnostics are a follow-on — see P4 item 16).
+
+Implementation notes:
+- New `src/operations/getTypeErrors.ts` — shared diagnostic extraction
+- `src/daemon/dispatcher.ts` — post-write hook after write ops; calls `invalidateFile()` then extracts diagnostics for `filesModified`
+- `src/mcp.ts` — new tool entry (after `getDefinition`, before `searchText`)
+- `src/schema.ts` / `src/types.ts` — schema + result types
+
+Acceptance criteria:
+- Standalone `getTypeErrors` tool returns type errors for a single file when `file` is provided
+- Standalone `getTypeErrors` tool returns project-wide errors when `file` is omitted, capped at 100 with `truncated: true` when exceeded
+- Write operations (rename, moveFile, moveSymbol, replaceText) include a `typeErrors` array in their response, containing errors from `filesModified` files only, capped at 20
+- Dispatcher refreshes modified files in the provider cache before extracting diagnostics (no stale AST)
+- Each diagnostic includes: `file` (absolute path), `line` (1-based), `col` (1-based), `code` (TS error number), `message`
+- Errors only — warnings/suggestions are excluded
+- `README.md` tool table updated, `docs/features/getTypeErrors.md` created
+- Tests cover: single-file errors, project-wide with cap, post-write diagnostics on rename, clean file returns empty array
+
 **9. `findReferences` by file path** `[needs design]`
 Feature doc: [`features/findReferences.md`](features/findReferences.md) — covers the symbol-position variant; the file-path variant needs a design section added.
 "Who imports this file?" is a different question from "who uses this symbol?". Options: union references across all exports (expensive), use `getEditsForFileRename` as a dry-run proxy (already available from `moveFile`), or scan import strings with the compiler's module resolver. Worth a separate design pass — keep separate from the symbol-position variant.
@@ -139,6 +163,9 @@ Scaffold a file with correct import paths inferred from its location.
 
 **14. `extractFunction`** `[needs design]`
 Pull a selection into a named function, updating the call site. High potential value but AST-level code generation is complex across all call-site shapes; wait until P1–P3 are stable.
+
+**16. `getTypeErrors` Volar support for `.vue` files** `[needs design]`
+Extend type error detection to `.vue` SFC `<script>` blocks via VolarProvider. Requires the same virtual-to-real path translation used by `findReferences` and `getDefinition` in Volar. Depends on P3 item 8 (TS-only `getTypeErrors`) shipping first. Design questions: whether to use `@volar/typescript` proxy's `getSemanticDiagnostics` or Volar's own diagnostic API, and how to map virtual-file positions back to SFC line numbers.
 
 **15. Claude Code plugin distribution**
 Feature docs: [`architecture.md`](architecture.md), [`features/daemon.md`](features/daemon.md)


### PR DESCRIPTION
## Summary
This PR reorganizes the feature roadmap in `docs/handoff.md` to reflect updated priorities and design clarity based on Phase 2 dogfooding insights.

## Key Changes

- **Promoted `getTypeErrors` from P4 to P3 (item 8)** — elevated due to high utility for post-write diagnostics. Includes detailed design spec:
  - Standalone MCP tool to check single file or whole project for type errors
  - Post-write diagnostics hook that appends errors to rename, moveFile, moveSymbol, and replaceText responses
  - Implementation notes covering new files, dispatcher integration, schema updates, and acceptance criteria
  - TS/TSX only; Vue SFC support deferred to P4

- **Moved `extractFunction` from P4 to P3 (item 10)** — recognized as one of the most common agent refactoring patterns alongside method extraction. Marked `[needs design]` pending AST-level code generation complexity analysis.

- **Renumbered P3 items** — `moveSymbol` (class methods) now item 9, `deleteFile` now item 17

- **Renumbered P4 items** — `findReferences` (file path) now item 18, new `getTypeErrors` Volar support for `.vue` files as item 16

- **Added P4 item 16** — `getTypeErrors` Volar support for `.vue` SFC files, depends on P3 item 8 shipping first

- **Minor clarification** — `findReferences` file-path variant notes that a workable approximation exists today via `searchText`

## Rationale
The reordering reflects lessons learned during Phase 2: type error feedback and function extraction are critical for agent-driven refactoring workflows and should ship before lower-priority tech debt items.

https://claude.ai/code/session_01J49mfCrHtWAip8UN8mYvMQ