### PR TITLE
Add agent-users design guide for tool interface decisions

### DIFF
--- a/docs/agent-users.md
+++ b/docs/agent-users.md
@@ -9,17 +9,25 @@
 
 light-bridge's primary users are AI coding agents — LLMs operating inside tool-use loops. They are not humans with a terminal. The differences matter for every interface decision: parameter design, defaults, response shapes, error messages, and what information to include or omit.
 
+## The core principle: prefer guardrails over assumptions
+
+Agents are poor at optimising and planning their own workflows. They won't anticipate that they'll need type errors after a rename, discover an opt-in flag and decide to use it, or batch related calls for efficiency. If the right workflow requires foresight, agents won't do it.
+
+**Build the foresight into the tool.** The tool should do the right thing by default — return the useful information, enforce the safe boundary, choose the sensible mode. Let agents opt *out* when they have a specific reason, but never require them to opt *in* to the obviously correct behaviour.
+
+This principle shows up in every section below. Each characteristic is a specific way agents lack foresight, and each design rule is a guardrail that compensates.
+
 ## How agents differ from humans
 
 ### They read the tool description, nothing else
 
 An agent discovers light-bridge through MCP tool descriptions. It will never browse a README, search a docs site, or read a changelog. If a capability isn't surfaced in the tool description the agent sees at call time, it doesn't exist. Opt-in flags that require the agent to know about a feature before using it are effectively invisible.
 
-### They don't reason about whether to ask for information — give it to them
+### They won't plan the optimal sequence of calls
 
-Every decision an agent makes costs reasoning tokens and risks a wrong choice. If type errors after a rename are useful (they are), return them by default — don't make the agent decide whether to request them. The useful default should be on; let agents opt *out* if they have a specific reason.
+A human might think "I'll rename this symbol, then check for type errors to make sure nothing broke." An agent operates one tool call at a time — it won't anticipate what information it will need after a mutation completes. If type errors after a rename are useful (they are), return them automatically. Don't expect the agent to plan a two-step workflow when the tool can just do it.
 
-**Design rule:** if you're adding a boolean flag, ask "would a competent human always turn this on?" If yes, it shouldn't be a flag.
+**Design rule:** if you're adding a boolean flag, ask "would a competent human always turn this on?" If yes, it shouldn't be a flag — it should be the default behaviour.
 
 ### They consume structured data, not prose
 
@@ -56,9 +64,10 @@ Each agent session starts fresh. Anything the agent learned in a previous sessio
 
 When speccing a feature, run through these questions:
 
-1. **Defaults:** Would a competent user always want this? → Make it the default, not a flag.
-2. **Response shape:** Is every field in the response immediately actionable? → If not, restructure or remove it.
-3. **Response size:** Could this response blow up for a large project? → Cap it, summarise it.
-4. **Parameters:** Is there exactly one obvious way to provide each value? → If not, tighten the description.
-5. **Errors:** Can the agent programmatically distinguish every failure mode? → If not, add an error code.
-6. **Discoverability:** Would an agent know this feature exists from the tool description alone? → If not, it won't be used.
+1. **Guardrails over assumptions:** Does any part of this design require the agent to have foresight about its own workflow? → Build that foresight into the tool instead.
+2. **Defaults:** Would a competent user always want this? → Make it the default, not a flag.
+3. **Response shape:** Is every field in the response immediately actionable? → If not, restructure or remove it.
+4. **Response size:** Could this response blow up for a large project? → Cap it, summarise it.
+5. **Parameters:** Is there exactly one obvious way to provide each value? → If not, tighten the description.
+6. **Errors:** Can the agent programmatically distinguish every failure mode? → If not, add an error code.
+7. **Discoverability:** Would an agent know this feature exists from the tool description alone? → If not, it won't be used.

--- a/docs/agent-users.md
+++ b/docs/agent-users.md
@@ -1,0 +1,64 @@
+**Purpose:** Characteristics of AI coding agents that should inform every design decision in light-bridge.
+**Audience:** Anyone designing or speccing a feature. Read this before writing a spec.
+**Status:** Current
+**Related docs:** [Why](why.md) (product rationale), [MCP transport](features/mcp-transport.md) (tool interface)
+
+---
+
+# Designing for agent users
+
+light-bridge's primary users are AI coding agents — LLMs operating inside tool-use loops. They are not humans with a terminal. The differences matter for every interface decision: parameter design, defaults, response shapes, error messages, and what information to include or omit.
+
+## How agents differ from humans
+
+### They read the tool description, nothing else
+
+An agent discovers light-bridge through MCP tool descriptions. It will never browse a README, search a docs site, or read a changelog. If a capability isn't surfaced in the tool description the agent sees at call time, it doesn't exist. Opt-in flags that require the agent to know about a feature before using it are effectively invisible.
+
+### They don't reason about whether to ask for information — give it to them
+
+Every decision an agent makes costs reasoning tokens and risks a wrong choice. If type errors after a rename are useful (they are), return them by default — don't make the agent decide whether to request them. The useful default should be on; let agents opt *out* if they have a specific reason.
+
+**Design rule:** if you're adding a boolean flag, ask "would a competent human always turn this on?" If yes, it shouldn't be a flag.
+
+### They consume structured data, not prose
+
+Agents parse JSON fields. A response like `{ filesModified: ["a.ts", "b.ts"], typeErrors: [...] }` is immediately actionable. A paragraph explaining what happened forces the agent to extract facts from natural language — slow, token-expensive, and error-prone.
+
+Return structured data. Use prose only in `description` fields that help the agent understand *what a tool does*, not in response payloads that tell it *what happened*.
+
+### They are literal interpreters
+
+Vague descriptions produce wrong usage. "The file path" doesn't tell the agent whether it wants absolute or relative, workspace-relative or cwd-relative. "Absolute path to the file within the workspace" does. Every parameter description should be specific enough that there's one obvious way to provide the value.
+
+### They have bounded context
+
+Every token in a response competes with the agent's reasoning capacity. Over-large responses — full file contents, verbose diffs, hundreds of type errors — push useful context out of the window and increase hallucination risk.
+
+Return summaries by default. Cap unbounded lists. Never return raw file contents when a structured summary would do.
+
+### They can't do interactive flows
+
+No confirmations, no multi-step wizards, no "did you mean X?" prompts. Every tool call must be a complete intent that produces a complete result. If an operation needs disambiguation, fail with a structured error that tells the agent exactly what to provide differently — don't ask it a question.
+
+### They retry mechanically on failure
+
+When a tool call fails, agents typically retry with slight variations. This means:
+- **Idempotency matters.** A rename that already happened should not fail on retry — or if it does, the error should make clear "this was already done" rather than "symbol not found."
+- **Error codes matter more than error messages.** Agents branch on structured error codes, not on parsing English sentences. Every distinct failure mode needs its own code.
+- **Transient vs permanent must be obvious.** `DAEMON_STARTING` is retriable; `SYMBOL_NOT_FOUND` is not. The agent shouldn't have to guess.
+
+### They don't remember across sessions
+
+Each agent session starts fresh. Anything the agent learned in a previous session — which tools are available, what parameters work best, which patterns to avoid — is gone. The tool interface must be self-describing every time: good tool descriptions, clear parameter docs, informative error messages. Don't design for a user who "learns" the tool over time.
+
+## Applying this to design
+
+When speccing a feature, run through these questions:
+
+1. **Defaults:** Would a competent user always want this? → Make it the default, not a flag.
+2. **Response shape:** Is every field in the response immediately actionable? → If not, restructure or remove it.
+3. **Response size:** Could this response blow up for a large project? → Cap it, summarise it.
+4. **Parameters:** Is there exactly one obvious way to provide each value? → If not, tighten the description.
+5. **Errors:** Can the agent programmatically distinguish every failure mode? → If not, add an error code.
+6. **Discoverability:** Would an agent know this feature exists from the tool description alone? → If not, it won't be used.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -13,10 +13,11 @@ Context that isn't in the feature docs — things you need to know before pickin
 
 **New to the codebase?** Read in this order:
 1. [`docs/why.md`](why.md) — what this is and why it exists
-2. [`docs/features/daemon.md`](features/daemon.md) — understand the daemon before touching `serve`
-3. [`docs/features/mcp-transport.md`](features/mcp-transport.md) — how `serve` connects to the daemon
-4. [`docs/architecture.md`](architecture.md) — provider/operation architecture; read before touching anything in `src/`
-5. [`docs/quality.md`](quality.md) — testing and reliability expectations
+2. [`docs/agent-users.md`](agent-users.md) — how agents differ from human users; read before speccing any feature
+3. [`docs/features/daemon.md`](features/daemon.md) — understand the daemon before touching `serve`
+4. [`docs/features/mcp-transport.md`](features/mcp-transport.md) — how `serve` connects to the daemon
+5. [`docs/architecture.md`](architecture.md) — provider/operation architecture; read before touching anything in `src/`
+6. [`docs/quality.md`](quality.md) — testing and reliability expectations
 
 **Picking up a task?** Tasks have one of two states:
 - **Has a spec link** → ready to implement. Read the spec, then run `/slice`.
@@ -157,6 +158,7 @@ Each concern has a dedicated doc. Read those — don't rely on handoff for desig
 
 | Topic | Doc |
 |-------|-----|
+| Agent user characteristics — design constraints for tool interfaces | [`docs/agent-users.md`](agent-users.md) |
 | Provider/operation architecture, dispatcher design, `ProviderRegistry` | [`docs/architecture.md`](architecture.md) |
 | MCP wire protocol, tool interface, `DAEMON_STARTING`, `filesSkipped` | [`docs/features/mcp-transport.md`](features/mcp-transport.md) |
 | Daemon lifecycle, auto-spawn, socket protocol | [`docs/features/daemon.md`](features/daemon.md) |

--- a/docs/specs/templates/bug.md
+++ b/docs/specs/templates/bug.md
@@ -32,6 +32,10 @@ is wrong."
 
 ## Fix
 
+> **Prompt:** If this bug affects a tool interface, response shape, or error path,
+> review [`docs/agent-users.md`](../../agent-users.md) — the fix should respect
+> agent-user constraints (structured errors, distinct codes, bounded output).
+
 Acceptance criteria for the fix:
 
 - [ ] [reproduction case] now produces [expected output]

--- a/docs/specs/templates/change.md
+++ b/docs/specs/templates/change.md
@@ -30,6 +30,11 @@ Acceptance criteria as concrete **input → output** statements.
 
 What changes on the public surface. Sketch the types — parameter names, return shape, error codes.
 
+> **Prompt:** Review [`docs/agent-users.md`](../../agent-users.md) before filling this section.
+> Agents are our primary users — run through the design checklist there:
+> defaults on, structured responses, capped output, unambiguous parameters,
+> distinct error codes, discoverable from the tool description alone.
+
 For every field and parameter, answer:
 
 - **What does it contain?** "string" is not enough. What information does it hold?


### PR DESCRIPTION
## Summary

Adds a new design guide documenting how AI coding agents differ from human users, establishing design principles and constraints that should inform every tool interface decision in light-bridge.

## Changes

- **New doc: `docs/agent-users.md`** — Comprehensive guide covering:
  - Core principle: "prefer guardrails over assumptions"
  - Seven key differences between agent and human users (discovery, planning, data consumption, literal interpretation, context bounds, interactivity, session memory)
  - Specific design rules for each difference
  - Practical checklist for feature specs (defaults, response shapes, parameter clarity, error codes, discoverability)

- **Updated `docs/handoff.md`** — Integrated agent-users guide into onboarding:
  - Added as step 2 in "New to the codebase" reading order (before daemon/architecture)
  - Added to reference table of design concerns
  - Positioned as prerequisite for feature specification

- **Updated spec templates** — Added guidance prompts:
  - `docs/specs/templates/change.md`: Reminder to review agent-users checklist before designing public surface
  - `docs/specs/templates/bug.md`: Reminder to respect agent constraints when fixing tool interfaces

## Rationale

Agents are light-bridge's primary users but operate fundamentally differently from humans — they can't discover features from docs, plan multi-step workflows, or learn from experience. This guide makes those constraints explicit and actionable, ensuring design decisions (parameter defaults, response structures, error handling) are optimized for agent usage rather than human assumptions.

https://claude.ai/code/session_01TwVbxhCwmCZfxjLpz8YQbe