### PR TITLE
Design deleteFile operation for compiler-aware file deletion

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -116,7 +116,7 @@ Stryker mutation testing is operational: `pnpm test:mutate`. See [`quality.md`](
 
 ### P3 — High-value features
 
-- `deleteFile` `[needs design]` — remove a file and clean up imports in referencing files
+- `deleteFile` → [`docs/specs/20260303-delete-file.md`](specs/20260303-delete-file.md) — remove a file and clean up imports in referencing files
 
 ---
 

--- a/docs/specs/20260303-delete-file.md
+++ b/docs/specs/20260303-delete-file.md
@@ -1,0 +1,111 @@
+# deleteFile operation
+
+**type:** change
+**date:** 2026-03-03
+**tracks:** handoff.md # deleteFile → docs/features/deleteFile.md
+
+---
+
+## Context
+
+Agents frequently need to delete files during refactoring — removing dead code, pruning stale modules, collapsing a barrel. Without compiler-aware deletion, the agent must manually find all importers with `searchText` and remove each import with `replaceText`, risking missed references. `deleteFile` collapses that workflow into one compiler-backed call that removes the file and cleans its import footprint in one step.
+
+## Value / Effort
+
+- **Value:** Saves a multi-step search-and-edit workflow for every file deletion involving imports. More importantly, it prevents silent breakage: a text-based approach can miss re-exports in barrel files, conditional imports in `export * from` chains, or out-of-project test files that import the deleted module. The compiler tracks these; `searchText` does not.
+- **Effort:** Medium. One new operation file, one new result type, schema entry, dispatcher entry, MCP tool entry, and feature doc. The core logic follows the `afterFileRename` pattern already in `TsProvider` — iterating source files, checking module specifiers, removing declarations, writing. No new provider interface method required; the operation uses `tsProvider.getProjectForFile()` directly (same pattern as `moveSymbol`). Vue SFC import cleanup is out of scope for this slice.
+
+## Behaviour
+
+- [ ] **AC1 — In-project cleanup (imports and re-exports):** Given a file `foo.ts` that is imported or re-exported by other TS/JS files in the project (`import { x } from './foo'`, `export { x } from './foo'`, `export * from './foo'`), the operation removes those declarations, writes the affected files, and returns `filesModified` listing them and `importRefsRemoved` with the count of removed declarations. The deleted file itself is absent from `filesModified`.
+
+  *Laziness test:* "only remove `import` declarations, ignore `export … from`" — fails because barrel files with `export * from './foo'` would not be cleaned.
+
+- [ ] **AC2 — Physical deletion:** After the operation, the target file no longer exists on disk. This holds even when the file has no importers (zero-importer case).
+
+  *Laziness test:* "only remove importers but leave the file" — fails because the file must be gone.
+
+- [ ] **AC3 — Out-of-project file cleanup:** TS/JS files in the workspace that are not included in the tsconfig (e.g. test files outside `src/`) and that import the deleted file are also cleaned. Their import/re-export declarations are removed and they appear in `filesModified`.
+
+  *Laziness test:* "only scan project source files via ts-morph, skip unlisted files" — fails for test fixtures outside `tsconfig.include`.
+
+- [ ] **AC4 — Workspace boundary on outputs:** If a file that imports the deleted target lies outside the workspace boundary, it is not written and its path appears in `filesSkipped`. In-workspace importers are still cleaned normally.
+
+  *Laziness test:* "error out when any importer is outside the workspace" — fails because in-workspace importers must still be cleaned and the out-of-boundary file returned in `filesSkipped`, not as an error.
+
+- [ ] **AC5 — FILE_NOT_FOUND error:** If the target file does not exist, the operation returns `{ ok: false, error: "FILE_NOT_FOUND", message: "…" }` without touching any other files.
+
+  *Laziness test:* "throw an unstructured exception" — fails because a structured error code is required so the agent can branch on it.
+
+## Interface
+
+### Input
+
+```typescript
+// Zod schema: DeleteFileArgsSchema
+{
+  file: string;            // Absolute path to the file to delete
+  checkTypeErrors?: boolean; // Default on; pass false to suppress post-write type check
+}
+```
+
+**`file`:** Absolute path to the `.ts`, `.tsx`, `.js`, or `.jsx` file to delete. Must be within the workspace (enforced by dispatcher `pathParams`). Example: `/project/src/utils/old-helper.ts`. Cannot be a directory.
+
+**`checkTypeErrors`:** Optional boolean. When true (default), runs type-error diagnostics on all `filesModified` after the deletion and includes `typeErrors`, `typeErrorCount`, `typeErrorsTruncated` in the response. Pass `false` to suppress. Agents will almost always want type errors — after deleting a file, callers that used its exports will break.
+
+### Output
+
+```typescript
+interface DeleteFileResult {
+  deletedFile: string;       // Absolute path of the file that was deleted
+  filesModified: string[];   // Files whose import/re-export declarations were cleaned
+  filesSkipped: string[];    // In-scope importers outside the workspace boundary — not written
+  importRefsRemoved: number; // Total number of import/export declarations removed
+  // + typeErrors / typeErrorCount / typeErrorsTruncated when checkTypeErrors is true (injected by dispatcher)
+}
+```
+
+**`deletedFile`:** Echo of the absolute path deleted. Useful for the agent to confirm the right file was targeted.
+
+**`filesModified`:** List of absolute paths written. Does not include `deletedFile` itself. May be empty if no project file imported the deleted file.
+
+**`filesSkipped`:** Absolute paths of files the operation found but did not write because they are outside `workspace`. Agents should surface this to the user.
+
+**`importRefsRemoved`:** Count of individual `import`/`export` declarations removed across all modified files. Zero is valid (file had no importers). Maximum realistically ~hundreds for a widely-used utility; no hard cap needed since we're removing, not returning the declarations.
+
+### Error codes
+
+| Code | When |
+|------|------|
+| `FILE_NOT_FOUND` | Target file does not exist on disk |
+| `WORKSPACE_VIOLATION` | Target path is outside the workspace (dispatcher layer, before invoke) |
+| `VALIDATION_ERROR` | Schema validation failed (e.g. empty `file` string) |
+
+### MCP tool description (draft)
+
+> "When deleting a file, use this instead of shell rm — it removes every import and re-export of the file from other project files before deleting it. Covers both in-project source files and out-of-project files (tests, scripts) that import the target. Returns filesModified (imports cleaned), filesSkipped (outside workspace, not written — surface to user), and importRefsRemoved. Type errors in modified files are returned automatically (typeErrors, typeErrorCount, typeErrorsTruncated); pass checkTypeErrors:false to suppress. .ts/.tsx/.js/.jsx only — Vue SFCs that import the file are not cleaned in this version."
+
+## Edges
+
+- **Deletion order:** The target file is deleted from disk only after all importer edits have been written. ts-morph needs the file present to resolve module specifiers during the scan.
+- **Self-reference:** The target file is excluded from the import scan (a file cannot import itself in normal code).
+- **Vue SFC importers:** `.vue` files that import the deleted file are NOT modified. They will not appear in `filesSkipped` either — they are simply not scanned. This is a known limitation for this slice; a follow-up can add regex-based `<script>` block scanning (same approach as `vue-scan.ts`).
+- **Workspace boundary on input:** Enforced by the dispatcher via `pathParams: ["file"]` before `invoke` is called.
+- **Provider cache after deletion:** After a file is deleted, `tsProvider.invalidateProject(file)` is called so the next request rebuilds the project. The file-system watcher will also trigger `invalidateAll` independently via the `unlink` event, but the operation must not rely on that.
+- **Side-effect imports:** `import './foo'` (no bindings) is also a declaration that must be removed — covered by AC1.
+- **Type-only imports:** `import type { Foo } from './foo'` is also a declaration — covered by AC1.
+- **Must not touch files outside workspace** — even if the compiler graph references them.
+- **Idempotency on retry:** If the file is already gone, return `FILE_NOT_FOUND`. Do not attempt to scan importers when the target is missing — the module specifier resolution would be unreliable.
+
+## Done-when
+
+- [ ] All 5 ACs verified by tests (unit tests using a fixture project)
+- [ ] Mutation score ≥ threshold for `src/operations/deleteFile.ts`
+- [ ] `pnpm check` passes (lint + build + test)
+- [ ] Docs updated:
+  - [ ] `docs/features/deleteFile.md` created
+  - [ ] `README.md` tool table updated
+  - [ ] `handoff.md` current-state section updated (operation count, layout)
+- [ ] Tech debt discovered during implementation added to handoff.md as `[needs design]`
+- [ ] Agent insights captured in `docs/agent-memory.md`
+- [ ] Spec moved to `docs/specs/archive/` with Outcome section appended

--- a/docs/specs/20260303-delete-file.md
+++ b/docs/specs/20260303-delete-file.md
@@ -12,12 +12,12 @@ Agents frequently need to delete files during refactoring — removing dead code
 
 ## Value / Effort
 
-- **Value:** Saves a multi-step search-and-edit workflow for every file deletion involving imports. More importantly, it prevents silent breakage: a text-based approach can miss re-exports in barrel files, conditional imports in `export * from` chains, or out-of-project test files that import the deleted module. The compiler tracks these; `searchText` does not.
-- **Effort:** Medium. One new operation file, one new result type, schema entry, dispatcher entry, MCP tool entry, and feature doc. The core logic follows the `afterFileRename` pattern already in `TsProvider` — iterating source files, checking module specifiers, removing declarations, writing. No new provider interface method required; the operation uses `tsProvider.getProjectForFile()` directly (same pattern as `moveSymbol`). Vue SFC import cleanup is out of scope for this slice.
+- **Value:** Saves a multi-step search-and-edit workflow for every file deletion involving imports. More importantly, it prevents silent breakage: a text-based approach can miss re-exports in barrel files, `export * from` chains, out-of-project test files, or Vue SFC script blocks that import the deleted module. The compiler tracks TS/JS references; the regex scan (same approach as `vue-scan.ts`) handles Vue SFCs.
+- **Effort:** Medium. One new operation file, one new result type, schema entry, dispatcher entry, MCP tool entry, and feature doc. The TS/JS cleanup follows the `afterFileRename` pattern already in `TsProvider`. The Vue cleanup adds one new function to `vue-scan.ts` — simpler than `updateVueImportsAfterMove` because deletion removes the line rather than rewriting the path.
 
 ## Behaviour
 
-- [ ] **AC1 — In-project cleanup (imports and re-exports):** Given a file `foo.ts` that is imported or re-exported by other TS/JS files in the project (`import { x } from './foo'`, `export { x } from './foo'`, `export * from './foo'`), the operation removes those declarations, writes the affected files, and returns `filesModified` listing them and `importRefsRemoved` with the count of removed declarations. The deleted file itself is absent from `filesModified`.
+- [ ] **AC1 — In-project TS/JS cleanup (imports and re-exports):** Given a file `foo.ts` that is imported or re-exported by other TS/JS files in the project (`import { x } from './foo'`, `export { x } from './foo'`, `export * from './foo'`), the operation removes those declarations, writes the affected files, and returns `filesModified` listing them and `importRefsRemoved` with the count of removed declarations. The deleted file itself is absent from `filesModified`.
 
   *Laziness test:* "only remove `import` declarations, ignore `export … from`" — fails because barrel files with `export * from './foo'` would not be cleaned.
 
@@ -25,15 +25,19 @@ Agents frequently need to delete files during refactoring — removing dead code
 
   *Laziness test:* "only remove importers but leave the file" — fails because the file must be gone.
 
-- [ ] **AC3 — Out-of-project file cleanup:** TS/JS files in the workspace that are not included in the tsconfig (e.g. test files outside `src/`) and that import the deleted file are also cleaned. Their import/re-export declarations are removed and they appear in `filesModified`.
+- [ ] **AC3 — Out-of-project TS/JS file cleanup:** TS/JS files in the workspace that are not included in the tsconfig (e.g. test files outside `src/`) and that import the deleted file are also cleaned. Their import/re-export declarations are removed and they appear in `filesModified`.
 
   *Laziness test:* "only scan project source files via ts-morph, skip unlisted files" — fails for test fixtures outside `tsconfig.include`.
 
-- [ ] **AC4 — Workspace boundary on outputs:** If a file that imports the deleted target lies outside the workspace boundary, it is not written and its path appears in `filesSkipped`. In-workspace importers are still cleaned normally.
+- [ ] **AC4 — Vue SFC cleanup:** `.vue` files in the workspace whose `<script>` or `<script setup>` blocks contain any import or re-export of the deleted file (`import { x } from './foo'`, `import * as x from './foo'`, `import './foo'`, `export * from './foo'`, etc.) have those lines removed. Modified `.vue` files appear in `filesModified`; `.vue` files outside the workspace boundary appear in `filesSkipped`.
+
+  *Laziness test:* "only clean TS/JS files, skip .vue files entirely" — fails because a `.vue` importer would be silently left broken.
+
+- [ ] **AC5 — Workspace boundary on outputs:** If any file (TS, JS, or Vue) that imports the deleted target lies outside the workspace boundary, it is not written and its path appears in `filesSkipped`. In-workspace importers are still cleaned normally.
 
   *Laziness test:* "error out when any importer is outside the workspace" — fails because in-workspace importers must still be cleaned and the out-of-boundary file returned in `filesSkipped`, not as an error.
 
-- [ ] **AC5 — FILE_NOT_FOUND error:** If the target file does not exist, the operation returns `{ ok: false, error: "FILE_NOT_FOUND", message: "…" }` without touching any other files.
+- [ ] **AC6 — FILE_NOT_FOUND error:** If the target file does not exist, the operation returns `{ ok: false, error: "FILE_NOT_FOUND", message: "…" }` without touching any other files.
 
   *Laziness test:* "throw an unstructured exception" — fails because a structured error code is required so the agent can branch on it.
 
@@ -49,7 +53,7 @@ Agents frequently need to delete files during refactoring — removing dead code
 }
 ```
 
-**`file`:** Absolute path to the `.ts`, `.tsx`, `.js`, or `.jsx` file to delete. Must be within the workspace (enforced by dispatcher `pathParams`). Example: `/project/src/utils/old-helper.ts`. Cannot be a directory.
+**`file`:** Absolute path to the `.ts`, `.tsx`, `.js`, `.jsx`, or `.vue` file to delete. Must be within the workspace (enforced by dispatcher `pathParams`). Example: `/project/src/utils/old-helper.ts`. Cannot be a directory.
 
 **`checkTypeErrors`:** Optional boolean. When true (default), runs type-error diagnostics on all `filesModified` after the deletion and includes `typeErrors`, `typeErrorCount`, `typeErrorsTruncated` in the response. Pass `false` to suppress. Agents will almost always want type errors — after deleting a file, callers that used its exports will break.
 
@@ -59,7 +63,7 @@ Agents frequently need to delete files during refactoring — removing dead code
 interface DeleteFileResult {
   deletedFile: string;       // Absolute path of the file that was deleted
   filesModified: string[];   // Files whose import/re-export declarations were cleaned
-  filesSkipped: string[];    // In-scope importers outside the workspace boundary — not written
+  filesSkipped: string[];    // Importers outside the workspace boundary — not written
   importRefsRemoved: number; // Total number of import/export declarations removed
   // + typeErrors / typeErrorCount / typeErrorsTruncated when checkTypeErrors is true (injected by dispatcher)
 }
@@ -67,7 +71,7 @@ interface DeleteFileResult {
 
 **`deletedFile`:** Echo of the absolute path deleted. Useful for the agent to confirm the right file was targeted.
 
-**`filesModified`:** List of absolute paths written. Does not include `deletedFile` itself. May be empty if no project file imported the deleted file.
+**`filesModified`:** List of absolute paths written. Does not include `deletedFile` itself. May be empty if no file imported the deleted file.
 
 **`filesSkipped`:** Absolute paths of files the operation found but did not write because they are outside `workspace`. Agents should surface this to the user.
 
@@ -83,24 +87,24 @@ interface DeleteFileResult {
 
 ### MCP tool description (draft)
 
-> "When deleting a file, use this instead of shell rm — it removes every import and re-export of the file from other project files before deleting it. Covers both in-project source files and out-of-project files (tests, scripts) that import the target. Returns filesModified (imports cleaned), filesSkipped (outside workspace, not written — surface to user), and importRefsRemoved. Type errors in modified files are returned automatically (typeErrors, typeErrorCount, typeErrorsTruncated); pass checkTypeErrors:false to suppress. .ts/.tsx/.js/.jsx only — Vue SFCs that import the file are not cleaned in this version."
+> "When deleting a file, use this instead of shell rm — it removes every import and re-export of the file from other project files before deleting it. Covers in-project source files, out-of-project files (tests, scripts), and Vue SFC script blocks. Returns filesModified (imports cleaned), filesSkipped (outside workspace, not written — surface to user), and importRefsRemoved. Type errors in modified files are returned automatically (typeErrors, typeErrorCount, typeErrorsTruncated); pass checkTypeErrors:false to suppress."
 
 ## Edges
 
-- **Deletion order:** The target file is deleted from disk only after all importer edits have been written. ts-morph needs the file present to resolve module specifiers during the scan.
+- **Deletion order:** The target file is deleted from disk only after all importer edits have been written. ts-morph needs the file present to resolve module specifiers during the TS/JS scan.
 - **Self-reference:** The target file is excluded from the import scan (a file cannot import itself in normal code).
-- **Vue SFC importers:** `.vue` files that import the deleted file are NOT modified. They will not appear in `filesSkipped` either — they are simply not scanned. This is a known limitation for this slice; a follow-up can add regex-based `<script>` block scanning (same approach as `vue-scan.ts`).
+- **Vue SFC scan scope:** `vue-scan.ts` uses regex against the raw SFC source — it covers `<script>` and `<script setup>` but does not parse template-level `import()` expressions. Consistent with how `updateVueImportsAfterMove` works today.
 - **Workspace boundary on input:** Enforced by the dispatcher via `pathParams: ["file"]` before `invoke` is called.
 - **Provider cache after deletion:** After a file is deleted, `tsProvider.invalidateProject(file)` is called so the next request rebuilds the project. The file-system watcher will also trigger `invalidateAll` independently via the `unlink` event, but the operation must not rely on that.
-- **Side-effect imports:** `import './foo'` (no bindings) is also a declaration that must be removed — covered by AC1.
-- **Type-only imports:** `import type { Foo } from './foo'` is also a declaration — covered by AC1.
+- **Side-effect imports:** `import './foo'` (no bindings) must be removed — covered by AC1/AC4.
+- **Type-only imports:** `import type { Foo } from './foo'` must be removed — covered by AC1/AC4.
 - **Must not touch files outside workspace** — even if the compiler graph references them.
-- **Idempotency on retry:** If the file is already gone, return `FILE_NOT_FOUND`. Do not attempt to scan importers when the target is missing — the module specifier resolution would be unreliable.
+- **Idempotency on retry:** If the file is already gone, return `FILE_NOT_FOUND`. Do not attempt to scan importers when the target is missing — module specifier resolution would be unreliable.
 
 ## Done-when
 
-- [ ] All 5 ACs verified by tests (unit tests using a fixture project)
-- [ ] Mutation score ≥ threshold for `src/operations/deleteFile.ts`
+- [ ] All 6 ACs verified by tests (unit tests using a fixture project)
+- [ ] Mutation score ≥ threshold for `src/operations/deleteFile.ts` and `src/providers/vue-scan.ts`
 - [ ] `pnpm check` passes (lint + build + test)
 - [ ] Docs updated:
   - [ ] `docs/features/deleteFile.md` created


### PR DESCRIPTION
## Summary

This PR introduces the design specification for a new `deleteFile` operation that removes files while automatically cleaning up all import and re-export declarations across the project. This addresses the gap where agents currently must manually search for and remove imports when deleting files, risking silent breakage from missed references in barrel files, re-export chains, and Vue SFCs.

## Changes

- **Added `docs/specs/20260303-delete-file.md`**: Comprehensive design spec covering:
  - Context and value proposition (prevents silent breakage vs. text-based deletion)
  - Six acceptance criteria (AC1–AC6) defining behavior for TS/JS cleanup, physical deletion, out-of-project files, Vue SFCs, workspace boundaries, and error handling
  - Input/output interface with `DeleteFileArgsSchema` and `DeleteFileResult` type
  - Error codes (`FILE_NOT_FOUND`, `WORKSPACE_VIOLATION`, `VALIDATION_ERROR`)
  - Edge cases (deletion order, self-references, Vue SFC scope, cache invalidation, idempotency)
  - Done-when checklist for implementation

- **Updated `docs/handoff.md`**: Moved `deleteFile` from `[needs design]` backlog to active design, linking to the new spec

## Implementation Scope

The spec defines a medium-effort feature requiring:
- One new operation file (`src/operations/deleteFile.ts`)
- One new result type and schema entry
- Extension to `TsProvider` following the `afterFileRename` pattern for TS/JS cleanup
- New function in `vue-scan.ts` for Vue SFC import removal
- MCP tool registration and feature documentation

## Key Design Decisions

- **Compiler-backed cleanup**: Uses ts-morph to track TS/JS references and regex scanning (via `vue-scan.ts`) for Vue SFCs, preventing missed re-exports and barrel file chains
- **Workspace boundary handling**: In-workspace importers are cleaned normally; out-of-workspace importers appear in `filesSkipped` rather than causing errors
- **Deletion order**: Target file deleted only after all importer edits are written (ts-morph needs the file present for module resolution)
- **Type checking**: Optional post-write type-error diagnostics (enabled by default) to surface broken callers

https://claude.ai/code/session_015oCrUUsHuWKn6x7hKDDFay