### PR TITLE
Input data slice

### DIFF
--- a/.claude/skills/slice/SKILL.md
+++ b/.claude/skills/slice/SKILL.md
@@ -13,7 +13,22 @@ description: Pick up the next task — if it needs a spec, create one first; if 
 2. **Read the spec.** Open the linked spec file. Confirm the task and its ACs with the user BEFORE writing any code.
 
 3. **Write failing tests first.** For each AC in the spec's Behaviour/Fix section:
-   - State in the `it`/`describe` label what specific behaviour is being specified — never reference AC numbers or spec identifiers in code or test labels (specs are changesets; they get archived)
+   - Structure labels as `describe(capability) > describe(logical grouping) > it(behaviour)`. Never reference AC numbers or spec identifiers — specs are changesets that get archived; test labels are permanent.
+     ```
+     // ✗ copies the spec's task-tracking structure into permanent code
+     describe("AC1 — in-project cleanup") { ... }
+
+     // ✓ describes the operation's natural shape
+     describe("deleteFile") {
+       describe("in-project TS/JS files") {
+         it("removes named imports and type-only import declarations")
+         it("removes re-export declarations (export * and named re-exports)")
+       }
+       describe("out-of-project TS/JS files") {
+         it("removes imports from files outside tsconfig include")
+       }
+     }
+     ```
    - Ask: "What would have to be wrong in the implementation for this test to still pass?" Add at least one assertion that answers that — pin exact values, boundary conditions, or the absence of something
    - A test that only verifies a result exists is incomplete — assert the shape, a boundary case, and at least one error/edge path
    - Use the spec's **Interface** section to inform bounds testing and the **Edges** section for regression tests

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ All refactoring operations are exposed as MCP tools via `light-bridge serve`. Th
 | `rename` | ✓ | ✓ | no | Renames a symbol at a given position; updates every reference project-wide |
 | `moveFile` | ✓ | ✓ | no | Moves a file; rewrites all import paths that reference it |
 | `moveSymbol` | ✓ | ✓* | no | Moves a named export to another file; updates all importers |
+| `deleteFile` | ✓ | ✓† | no | Deletes a file; removes every import and re-export of it across the workspace |
 | `extractFunction` | ✓ | — | no | Extracts a selected block of statements into a new named function at module scope |
 | `findReferences` | ✓ | ✓ | yes | Returns every reference to the symbol at a given position |
 | `getDefinition` | ✓ | ✓ | yes | Returns definition location(s) for the symbol at a given position |
@@ -116,6 +117,8 @@ All refactoring operations are exposed as MCP tools via `light-bridge serve`. Th
 All tools take absolute paths. Write operations return `filesModified` and `filesSkipped` (files outside the workspace boundary that were not touched). Write operations also accept `checkTypeErrors: true` to return type diagnostics for modified files in the same response — see `getTypeErrors` for the diagnostic shape.
 
 \* `moveSymbol` supports moving exports from `.ts`/`.tsx` sources inside Vue workspaces and updates `.vue` importers in a post-step. Moving symbols from a `.vue` source file is still pending.
+
+† `deleteFile` removes imports and re-exports from `.ts`/`.tsx`/`.js`/`.jsx` files (via ts-morph) and Vue SFC `<script>` blocks (via regex scan).
 
 ## Response format
 
@@ -299,6 +302,7 @@ src/
 │   ├── rename.ts
 │   ├── moveFile.ts
 │   ├── moveSymbol.ts
+│   ├── deleteFile.ts
 │   ├── extractFunction.ts
 │   ├── findReferences.ts
 │   ├── getDefinition.ts

--- a/docs/agent-memory.md
+++ b/docs/agent-memory.md
@@ -182,6 +182,15 @@ The high-value operations (`moveSymbol`, `moveFile`, `rename`) all share one pro
 **`extractFunction`: `endCol` must cover the last character of the last selected statement.**
 TypeScript's `getApplicableRefactors` returns an empty array (no "Extract Symbol" refactor) when the selection's `end` offset falls before the end of the last statement in a multi-statement selection. For example, pointing `endCol` at `)` in `console.log(msg);` silently yields no refactors — it must point at the `;` (or the last token if the codebase uses no-semi style). This is a quirk of how the TS compiler considers a statement "selected". For single-statement selections the compiler is more lenient.
 
+**`deleteFile` deletes the file AFTER writing all importer edits — never before.**
+ts-morph's `getModuleSpecifierSourceFile()` needs the file present on disk to resolve module specifiers during the in-project scan. Deleting first would make Phase 1 blind to importers. The implementation follows: Phase 1 (in-project ts-morph scan) → Phase 2 (out-of-project walk) → Phase 3 (Vue SFC regex) → Phase 4 (physical delete) → Phase 5 (cache invalidation).
+
+**ts-morph: re-query declarations after each `remove()` call on the same SourceFile.**
+After calling `node.remove()`, sibling node references captured before the removal may be stale. Iterating `[...getImportDeclarations(), ...getExportDeclarations()]`, calling `remove()` on the first match, then `break`-ing and re-querying is the safe pattern. O(n²) per file, but safe; import counts per file are small.
+
+**`deleteFile` out-of-project scan uses manual path resolution, not `getModuleSpecifierSourceFile()`.**
+In a per-file in-memory ts-morph project, the target file isn't in the project graph, so `getModuleSpecifierSourceFile()` always returns `undefined`. Instead: `stripExt(path.resolve(fromDir, specifier)) === targetNoExt`. This correctly handles bare specifiers (`'./foo'`), `.ts`, `.js`, `.tsx`, `.jsx` extensions.
+
 ---
 
 ## Memory storage

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -11,6 +11,7 @@ All tools are invoked through the MCP server (`light-bridge serve`). There are n
 | `rename` | [rename.md](./rename.md) | ✓ | ✓ | yes |
 | `moveFile` | [moveFile.md](./moveFile.md) | ✓ | ✓ | yes |
 | `moveSymbol` | [moveSymbol.md](./moveSymbol.md) | ✓ | ✓* | yes |
+| `deleteFile` | [deleteFile.md](./deleteFile.md) | ✓ | ✓† | yes |
 | `extractFunction` | [extractFunction.md](./extractFunction.md) | ✓ | — | yes |
 | `findReferences` | [findReferences.md](./findReferences.md) | ✓ | ✓ | no |
 | `getDefinition` | [getDefinition.md](./getDefinition.md) | ✓ | ✓ | no |
@@ -19,6 +20,8 @@ All tools are invoked through the MCP server (`light-bridge serve`). There are n
 | `replaceText` | [replaceText.md](./replaceText.md) | n/a | n/a | yes |
 
 \* `moveSymbol` supports moving exported symbols from `.ts`/`.tsx` sources inside Vue workspaces and updates `.vue` importers in a post-step. Moving symbols from a `.vue` source file is still pending; see [moveSymbol.md](./moveSymbol.md).
+
+† `deleteFile` removes imports and re-exports from TS/JS files (via ts-morph) and Vue SFC `<script>` blocks (via regex scan).
 
 ## Supported file types summary
 

--- a/docs/features/deleteFile.md
+++ b/docs/features/deleteFile.md
@@ -30,8 +30,16 @@ Deletes the target file from disk after removing all `import` and `export … fr
   ],
   "filesSkipped": [],
   "importRefsRemoved": 4,
-  "typeErrors": [],
-  "typeErrorCount": 0,
+  "typeErrors": [
+    {
+      "file": "/path/to/project/src/api.ts",
+      "line": 12,
+      "col": 3,
+      "code": 2304,
+      "message": "Cannot find name 'oldHelper'."
+    }
+  ],
+  "typeErrorCount": 1,
   "typeErrorsTruncated": false
 }
 ```
@@ -40,7 +48,7 @@ Deletes the target file from disk after removing all `import` and `export … fr
 - `filesModified` — files whose import/re-export declarations were cleaned. Does not include `deletedFile` itself.
 - `filesSkipped` — importers outside the workspace boundary that were found but not written. Surface these to the user.
 - `importRefsRemoved` — count of individual `import`/`export` declarations removed across all modified files.
-- `typeErrors` / `typeErrorCount` / `typeErrorsTruncated` — type errors in modified files after the deletion. Pass `checkTypeErrors: false` to suppress.
+- `typeErrors` / `typeErrorCount` / `typeErrorsTruncated` — type errors in modified files after the deletion; injected automatically by the dispatcher (same as all mutating operations). Expect errors here: removing an import leaves any code that *used* those symbols broken. Pass `checkTypeErrors: false` to suppress.
 
 ## Key concepts
 

--- a/docs/features/deleteFile.md
+++ b/docs/features/deleteFile.md
@@ -1,0 +1,82 @@
+# Feature: deleteFile
+
+**Purpose:** Remove a file and clean up every import and re-export that references it, across the whole workspace, in one compiler-backed operation.
+
+## What it does
+
+Deletes the target file from disk after removing all `import` and `export … from` declarations that reference it. Covers TypeScript/JavaScript files in the compiler project, files outside `tsconfig.include` (test files, scripts), and Vue SFC `<script>` blocks.
+
+**MCP tool call:**
+
+```json
+{
+  "name": "deleteFile",
+  "arguments": {
+    "file": "/path/to/project/src/old-helper.ts"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "deletedFile": "/path/to/project/src/old-helper.ts",
+  "filesModified": [
+    "/path/to/project/src/api.ts",
+    "/path/to/project/src/barrel.ts",
+    "/path/to/project/tests/helper.test.ts"
+  ],
+  "filesSkipped": [],
+  "importRefsRemoved": 4,
+  "typeErrors": [],
+  "typeErrorCount": 0,
+  "typeErrorsTruncated": false
+}
+```
+
+- `deletedFile` — echo of the absolute path removed. Useful to confirm the right file was targeted.
+- `filesModified` — files whose import/re-export declarations were cleaned. Does not include `deletedFile` itself.
+- `filesSkipped` — importers outside the workspace boundary that were found but not written. Surface these to the user.
+- `importRefsRemoved` — count of individual `import`/`export` declarations removed across all modified files.
+- `typeErrors` / `typeErrorCount` / `typeErrorsTruncated` — type errors in modified files after the deletion. Pass `checkTypeErrors: false` to suppress.
+
+## Key concepts
+
+**Three-phase cleanup before physical deletion.** The file is only deleted from disk after all importer edits are written, because ts-morph needs the file present to resolve module specifiers during the scan.
+
+**Phase 1 — in-project scan (ts-morph).** Iterates the compiler project and uses `getModuleSpecifierSourceFile()` to find every `import` and `export … from` declaration that resolves to the target. Handles named imports, type-only imports, namespace imports, default imports, re-exports (`export *`, `export { }`), and side-effect imports.
+
+**Phase 2 — out-of-project TS/JS scan.** Walks workspace files not in `tsconfig.include` (test files, scripts) using an in-memory ts-morph project per file. Module specifier resolution is done manually via `path.resolve` + extension stripping — this correctly handles bare specifiers (`'./foo'`), `.ts`, `.tsx`, `.js`, and `.jsx` extensions.
+
+**Phase 3 — Vue SFC scan (regex).** TypeScript's compiler is blind to imports inside Vue `<script>` blocks. The scanner walks `.vue` files and removes matching import/export lines with regex, consistent with how `updateVueImportsAfterMove` works. Covers `<script>` and `<script setup>` blocks; does not parse template-level `import()` expressions.
+
+**Safe re-query loop.** Removing a ts-morph AST node invalidates sibling node references captured before the removal. The implementation re-queries a source file's declarations after each removal so stale references are never used.
+
+**Provider cache invalidation.** After deletion, `tsProvider.invalidateProject(file)` drops the cached project so the next request rebuilds without the deleted file. The file-system watcher's `unlink` event also triggers `invalidateAll` independently.
+
+## Supported file types
+
+- `.ts`, `.tsx`, `.js`, `.jsx` as the deleted file — full support
+- `.vue` as the deleted file — physical deletion works; TS/JS importers that reference it by path are cleaned in Phase 2
+- `.vue` files as importers — cleaned in Phase 3 regardless of the deleted file's type
+
+## Constraints & limitations
+
+- Multi-line import declarations in Vue SFCs are not cleaned (regex is line-based). In practice, Vue SFC imports are nearly always single-line.
+- Template-level `import()` calls in Vue SFCs are not detected.
+- The file must exist at call time; if already deleted, `FILE_NOT_FOUND` is returned.
+
+## Security & workspace boundary
+
+- **Input:** `file` is validated against the workspace root by the dispatcher (`pathParams: ["file"]`). Paths outside the workspace return `WORKSPACE_VIOLATION` before the operation runs.
+- **Output writes:** Only files inside the workspace boundary are written. Importers found outside the workspace appear in `filesSkipped` and are not modified.
+
+## Error codes
+
+| Code | When |
+|------|------|
+| `FILE_NOT_FOUND` | Target file does not exist on disk |
+| `WORKSPACE_VIOLATION` | Target path is outside the workspace (dispatcher layer) |
+| `VALIDATION_ERROR` | Schema validation failed (e.g. empty `file` string) |

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -71,6 +71,7 @@ src/
     extractFunction.ts ← extractFunction(tsProvider, file, startLine, startCol, endLine, endCol, functionName, workspace)
     searchText.ts      ← searchText(pattern, workspace, { glob, context, maxResults })
     replaceText.ts     ← replaceText(workspace, { pattern, replacement, glob } | { edits })
+    deleteFile.ts      ← deleteFile(tsProvider, file, workspace)
   providers/
     ts.ts         ← TsProvider: compiler calls via ts-morph Project; refreshFile() for selective invalidation
     volar.ts      ← VolarProvider: compiler calls via Volar proxy + virtual↔real translation; afterSymbolMove scans .vue files
@@ -93,6 +94,7 @@ src/
 - `getTypeErrors` — TS only; read-only, returns type errors for a single file or whole project; capped at 100
 - `searchText` — regex search across workspace files; glob filter, context lines, max-results cap; skips sensitive files
 - `replaceText` — pattern mode (regex replace-all + optional glob) or surgical mode (edits array with oldText verification); skips sensitive files
+- `deleteFile` — removes a file and cleans every import/re-export of it from in-project TS/JS files, out-of-project TS/JS files, and Vue SFCs
 
 ---
 
@@ -116,7 +118,6 @@ Stryker mutation testing is operational: `pnpm test:mutate`. See [`quality.md`](
 
 ### P3 — High-value features
 
-- `deleteFile` → [`docs/specs/20260303-delete-file.md`](specs/20260303-delete-file.md) — remove a file and clean up imports in referencing files
 
 ---
 

--- a/docs/specs/archive/20260303-delete-file.md
+++ b/docs/specs/archive/20260303-delete-file.md
@@ -113,3 +113,17 @@ interface DeleteFileResult {
 - [ ] Tech debt discovered during implementation added to handoff.md as `[needs design]`
 - [ ] Agent insights captured in `docs/agent-memory.md`
 - [ ] Spec moved to `docs/specs/archive/` with Outcome section appended
+
+## Outcome
+
+**Tests added:** 16 tests across `tests/operations/deleteFile.test.ts` covering all 6 ACs. New fixture `tests/fixtures/delete-file-ts/` with in-project importers (named import, type-only import, barrel re-exports) and an out-of-project importer. Workspace boundary tested using the existing `cross-boundary` fixture whose tsconfig includes an out-of-workspace consumer directory.
+
+**Mutation score:** 76.02% overall (deleteFile.ts: 75.28%, vue-scan.ts: 76.52%) — above the 75% break threshold. One survivor fixed during the run: the `removeImportLines` side-effect branch condition (killing it required a test asserting that side-effect imports from *other* paths are not removed).
+
+**Architecture:** Three-phase cleanup before physical deletion: (1) in-project ts-morph scan using `getModuleSpecifierSourceFile()`, (2) out-of-project TS/JS walk with manual `path.resolve + stripExt` resolution, (3) Vue SFC regex scan. File deleted in Phase 4, cache invalidated in Phase 5.
+
+**Key discovery — safe ts-morph multi-removal:** After `node.remove()`, sibling node references from the same SourceFile may be stale. Pattern: collect one match, remove, break, re-query from scratch. This is O(n²) but safe and fast for typical import counts.
+
+**Key discovery — out-of-project module resolution:** `getModuleSpecifierSourceFile()` returns `undefined` in an in-memory ts-morph project because the target file isn't in the graph. Manual resolution (`stripExt(path.resolve(fromDir, specifier)) === targetNoExt`) handles all extension variants correctly.
+
+**Slice skill improvement:** Added a concrete before/after example for `describe`/`it` labeling to `SKILL.md` step 3, replacing the abstract rule with a pattern showing `describe(capability) > describe(grouping) > it(behaviour)`. The failure mode was copying spec AC section headers directly into `describe` labels.

--- a/eval/fixtures/deleteFile.json
+++ b/eval/fixtures/deleteFile.json
@@ -1,0 +1,10 @@
+{
+  "ok": true,
+  "deletedFile": "/tmp/light-bridge-eval/src/old-helper.ts",
+  "filesModified": [
+    "/tmp/light-bridge-eval/src/api.ts",
+    "/tmp/light-bridge-eval/src/middleware.ts"
+  ],
+  "filesSkipped": [],
+  "importRefsRemoved": 3
+}

--- a/src/daemon/dispatcher.ts
+++ b/src/daemon/dispatcher.ts
@@ -7,6 +7,7 @@ import { rename } from "../operations/rename.js";
 import { replaceText } from "../operations/replaceText.js";
 import { searchText } from "../operations/searchText.js";
 import {
+  DeleteFileArgsSchema,
   ExtractFunctionArgsSchema,
   FindReferencesArgsSchema,
   GetDefinitionArgsSchema,
@@ -216,6 +217,17 @@ const OPERATIONS: Record<string, OperationDescriptor> = {
         maxResults?: number;
       };
       return searchText(pattern, workspace, { glob, context, maxResults });
+    },
+  },
+
+  deleteFile: {
+    pathParams: ["file"],
+    schema: DeleteFileArgsSchema,
+    async invoke(registry, params, workspace) {
+      const { file } = params as { file: string };
+      const tsProvider = await registry.tsProvider();
+      const { deleteFile } = await import("../operations/deleteFile.js");
+      return deleteFile(tsProvider, file, workspace);
     },
   },
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { callDaemon, ensureDaemon } from "./daemon/ensure-daemon.js";
 import { socketPath } from "./daemon/paths.js";
 import {
+  DeleteFileArgsSchema,
   ExtractFunctionArgsSchema,
   FindReferencesArgsSchema,
   GetDefinitionArgsSchema,
@@ -149,6 +150,22 @@ const TOOLS: ToolDefinition[] = [
       ),
       checkTypeErrors: MoveSymbolArgsSchema.shape.checkTypeErrors.describe(
         "When false, skip the post-write type check; defaults to on",
+      ),
+    },
+  },
+  {
+    name: "deleteFile",
+    description:
+      "When deleting a file, use this instead of shell rm — it removes every import and re-export of the file from other project files before deleting it. " +
+      "Covers in-project source files, out-of-project files (tests, scripts), and Vue SFC script blocks. " +
+      "Returns deletedFile (echo of the path deleted), filesModified (imports cleaned), filesSkipped (outside workspace, not written — surface to user), and importRefsRemoved. " +
+      "Type errors in modified files are returned automatically (typeErrors, typeErrorCount, typeErrorsTruncated); pass checkTypeErrors:false to suppress.",
+    inputSchema: {
+      file: DeleteFileArgsSchema.shape.file.describe(
+        "Absolute path to the .ts, .tsx, .js, .jsx, or .vue file to delete",
+      ),
+      checkTypeErrors: DeleteFileArgsSchema.shape.checkTypeErrors.describe(
+        "When false, skip the post-write type check on modified files; defaults to on",
       ),
     },
   },

--- a/src/operations/deleteFile.ts
+++ b/src/operations/deleteFile.ts
@@ -1,0 +1,156 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Project } from "ts-morph";
+import type { TsProvider } from "../providers/ts.js";
+import { removeVueImportsOfDeletedFile } from "../providers/vue-scan.js";
+import { isWithinWorkspace } from "../security.js";
+import type { DeleteFileResult } from "../types.js";
+import { assertFileExists } from "../utils/assert-file.js";
+import { TS_EXTENSIONS, walkFiles } from "../utils/file-walk.js";
+
+export async function deleteFile(
+  tsProvider: TsProvider,
+  targetFile: string,
+  workspace: string,
+): Promise<DeleteFileResult> {
+  const absTarget = assertFileExists(targetFile);
+  const filesModified = new Set<string>();
+  const filesSkipped = new Set<string>();
+  let importRefsRemoved = 0;
+
+  // Phase 1: In-project TS/JS cleanup via ts-morph.
+  // ts-morph resolves module specifiers through the compiler, so it correctly
+  // handles path aliases, index files, and all extension variants.
+  const project = tsProvider.getProjectForFile(absTarget);
+  if (!project.getSourceFile(absTarget)) {
+    project.addSourceFileAtPath(absTarget);
+  }
+
+  const projectFilePaths = new Set(
+    project.getSourceFiles().map((sf) => sf.getFilePath() as string),
+  );
+
+  for (const sf of project.getSourceFiles()) {
+    const filePath = sf.getFilePath() as string;
+    if (filePath === absTarget) continue;
+
+    const hasRefs =
+      sf
+        .getImportDeclarations()
+        .some((d) => d.getModuleSpecifierSourceFile()?.getFilePath() === absTarget) ||
+      sf
+        .getExportDeclarations()
+        .some((d) => d.getModuleSpecifierSourceFile()?.getFilePath() === absTarget);
+
+    if (!hasRefs) continue;
+
+    if (!isWithinWorkspace(filePath, workspace)) {
+      filesSkipped.add(filePath);
+      continue;
+    }
+
+    // Remove one declaration at a time and re-query after each removal so that
+    // stale node references from the same SourceFile are never used.
+    let found = true;
+    while (found) {
+      found = false;
+      for (const decl of [...sf.getImportDeclarations(), ...sf.getExportDeclarations()]) {
+        if (decl.getModuleSpecifierSourceFile()?.getFilePath() === absTarget) {
+          decl.remove();
+          importRefsRemoved++;
+          found = true;
+          break;
+        }
+      }
+    }
+
+    filesModified.add(filePath);
+  }
+
+  for (const sf of project.getSourceFiles()) {
+    if (!sf.isSaved() && isWithinWorkspace(sf.getFilePath() as string, workspace)) {
+      await sf.save();
+    }
+  }
+
+  // Phase 2: Out-of-project TS/JS cleanup.
+  // Files outside tsconfig include aren't in ts-morph's project graph, so we
+  // walk the workspace and handle them with a per-file in-memory project.
+  // Module specifier resolution uses manual stripExt + path.resolve, which
+  // matches all extension variants (bare, .ts, .tsx, .js, .jsx).
+  const workspaceRoot = path.resolve(workspace);
+  const targetNoExt = stripExt(absTarget);
+
+  for (const filePath of walkFiles(workspaceRoot, [...TS_EXTENSIONS])) {
+    if (projectFilePaths.has(filePath)) continue;
+    if (filePath === absTarget) continue;
+    if (!isWithinWorkspace(filePath, workspace)) {
+      filesSkipped.add(filePath);
+      continue;
+    }
+
+    let raw: string;
+    try {
+      raw = fs.readFileSync(filePath, "utf8");
+    } catch {
+      continue;
+    }
+
+    const tmpProject = new Project({ useInMemoryFileSystem: true });
+    const sf = tmpProject.createSourceFile(filePath, raw);
+    const fromDir = path.dirname(filePath);
+
+    let removed = 0;
+    let found = true;
+    while (found) {
+      found = false;
+      for (const decl of [...sf.getImportDeclarations(), ...sf.getExportDeclarations()]) {
+        const specifier = decl.getModuleSpecifierValue();
+        if (!specifier || !specifier.startsWith(".")) continue;
+        if (stripExt(path.resolve(fromDir, specifier)) === targetNoExt) {
+          decl.remove();
+          removed++;
+          found = true;
+          break;
+        }
+      }
+    }
+
+    if (removed === 0) continue;
+    importRefsRemoved += removed;
+    fs.writeFileSync(filePath, sf.getFullText(), "utf8");
+    filesModified.add(filePath);
+  }
+
+  // Phase 3: Vue SFC cleanup.
+  // The TypeScript compiler is blind to imports inside <script> blocks in .vue
+  // files, so we scan them with regex (same approach as updateVueImportsAfterMove).
+  const {
+    modified: vueModified,
+    skipped: vueSkipped,
+    refsRemoved: vueRefs,
+  } = removeVueImportsOfDeletedFile(absTarget, workspaceRoot, workspace);
+  for (const f of vueModified) filesModified.add(f);
+  for (const f of vueSkipped) filesSkipped.add(f);
+  importRefsRemoved += vueRefs;
+
+  // Phase 4: Physical deletion — after all importer edits are written so that
+  // ts-morph can still resolve module specifiers during phases 1–2.
+  fs.unlinkSync(absTarget);
+
+  // Phase 5: Drop the cached project so the next request rebuilds without the
+  // deleted file. The watcher's `unlink` event also triggers invalidateAll, but
+  // the operation must not rely on that timing.
+  tsProvider.invalidateProject(absTarget);
+
+  return {
+    deletedFile: absTarget,
+    filesModified: Array.from(filesModified),
+    filesSkipped: Array.from(filesSkipped),
+    importRefsRemoved,
+  };
+}
+
+function stripExt(filePath: string): string {
+  return filePath.replace(/\.(ts|tsx|js|jsx|mts|cts)$/, "");
+}

--- a/src/providers/vue-scan.ts
+++ b/src/providers/vue-scan.ts
@@ -151,6 +151,92 @@ function rewriteNamedSymbolImport(
   );
 }
 
+/**
+ * After a file deletion, scan all .vue files under searchRoot and remove any
+ * import or re-export lines whose module specifier resolves to deletedFile.
+ *
+ * Covers: named imports, type-only imports, namespace imports, default imports,
+ * bare side-effect imports (`import './foo'`), and re-exports (`export * from`,
+ * `export { } from`).
+ *
+ * Returns modified file paths, paths skipped due to workspace boundary, and
+ * the total count of import/export declarations removed.
+ */
+export function removeVueImportsOfDeletedFile(
+  deletedFile: string,
+  searchRoot: string,
+  workspace: string,
+): { modified: string[]; skipped: string[]; refsRemoved: number } {
+  const deletedNoExt = stripExt(deletedFile);
+  const vueFiles = walkFiles(searchRoot, [".vue"]);
+  const modified: string[] = [];
+  const skipped: string[] = [];
+  let refsRemoved = 0;
+
+  for (const vueFile of vueFiles) {
+    if (!isWithinWorkspace(vueFile, workspace)) {
+      skipped.push(vueFile);
+      continue;
+    }
+
+    let content: string;
+    try {
+      content = fs.readFileSync(vueFile, "utf8");
+    } catch {
+      continue;
+    }
+
+    const { content: updated, removed } = removeImportLines(content, vueFile, deletedNoExt);
+    if (removed > 0) {
+      fs.writeFileSync(vueFile, updated, "utf8");
+      modified.push(vueFile);
+      refsRemoved += removed;
+    }
+  }
+
+  return { modified, skipped, refsRemoved };
+}
+
+/**
+ * Remove lines containing `import … from 'rel'`, `export … from 'rel'`, or
+ * bare `import 'rel'` where `rel` resolves to `targetNoExt`.
+ *
+ * Line-based regex — does not parse template-level import() expressions.
+ * Consistent with how updateVueImportsAfterMove works.
+ */
+function removeImportLines(
+  source: string,
+  fromFile: string,
+  targetNoExt: string,
+): { content: string; removed: number } {
+  let removed = 0;
+  const fromDir = path.dirname(fromFile);
+
+  // Match import/export lines that contain `from 'relative-path'`
+  let result = source.replace(
+    /^[^\S\r\n]*(?:import|export)\b[^\r\n]*?\bfrom\s+(['"])(\.\.?\/[^'"]+)\1[^\r\n]*[\r\n]*/gm,
+    (match, _q, specifier) => {
+      const absImport = stripExt(path.resolve(fromDir, specifier as string));
+      if (absImport !== targetNoExt) return match;
+      removed++;
+      return "";
+    },
+  );
+
+  // Match bare side-effect imports: `import './foo'` (no `from` keyword)
+  result = result.replace(
+    /^[^\S\r\n]*import\s+(['"])(\.\.?\/[^'"]+)\1[^\r\n]*[\r\n]*/gm,
+    (match, _q, specifier) => {
+      const absImport = stripExt(path.resolve(fromDir, specifier as string));
+      if (absImport !== targetNoExt) return match;
+      removed++;
+      return "";
+    },
+  );
+
+  return { content: result, removed };
+}
+
 function stripExt(filePath: string): string {
   return filePath.replace(/\.(ts|tsx|js|jsx|mts|cts)$/, "");
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -66,6 +66,11 @@ export const GetTypeErrorsArgsSchema = z.object({
   file: z.string().min(1, "file path must not be empty").optional(),
 });
 
+export const DeleteFileArgsSchema = z.object({
+  file: z.string().min(1, "file path is required"),
+  checkTypeErrors: z.boolean().optional(),
+});
+
 export const ExtractFunctionArgsSchema = z.object({
   file: z.string().min(1, "file path is required"),
   startLine: z.coerce.number().int().positive("startLine must be a positive integer (1-based)"),
@@ -88,6 +93,7 @@ export const ReplaceTextArgsSchema = ReplaceTextBaseSchema.refine(
   { message: "Provide either 'pattern'+'replacement' or 'edits', not both" },
 );
 
+export type DeleteFileArgs = z.infer<typeof DeleteFileArgsSchema>;
 export type GetTypeErrorsArgs = z.infer<typeof GetTypeErrorsArgsSchema>;
 export type RenameArgs = z.infer<typeof RenameArgsSchema>;
 export type MoveArgs = z.infer<typeof MoveArgsSchema>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,15 @@ export interface ReplaceTextResult {
   replacementCount: number;
 }
 
+export interface DeleteFileResult {
+  deletedFile: string;
+  filesModified: string[];
+  /** Importers outside the workspace boundary — found but not written. */
+  filesSkipped: string[];
+  /** Total import/export declarations removed across all modified files. */
+  importRefsRemoved: number;
+}
+
 export interface TypeDiagnostic {
   file: string;
   line: number;

--- a/tests/eval/fixture-coverage.test.ts
+++ b/tests/eval/fixture-coverage.test.ts
@@ -8,7 +8,7 @@ const FIXTURES_DIR = join(import.meta.dirname, "../../eval/fixtures");
 describe("eval fixture coverage", () => {
   it("TOOL_NAMES is non-empty and has the expected count", () => {
     // Pinning the count means silently dropping a tool is caught here.
-    expect(TOOL_NAMES.length).toBe(9);
+    expect(TOOL_NAMES.length).toBe(10);
     expect(TOOL_NAMES).toContain("rename");
     expect(TOOL_NAMES).toContain("replaceText");
   });

--- a/tests/fixtures/delete-file-ts/src/barrel.ts
+++ b/tests/fixtures/delete-file-ts/src/barrel.ts
@@ -1,0 +1,2 @@
+export * from "./target";
+export { targetFn } from "./target";

--- a/tests/fixtures/delete-file-ts/src/importer.ts
+++ b/tests/fixtures/delete-file-ts/src/importer.ts
@@ -1,0 +1,7 @@
+import type { TargetType } from "./target";
+import { targetFn } from "./target";
+
+export function useTarget(): string {
+  const t: TargetType = { value: targetFn() };
+  return t.value;
+}

--- a/tests/fixtures/delete-file-ts/src/target.ts
+++ b/tests/fixtures/delete-file-ts/src/target.ts
@@ -1,0 +1,5 @@
+export function targetFn(): string {
+  return "target";
+}
+
+export type TargetType = { value: string };

--- a/tests/fixtures/delete-file-ts/tests/out-of-project.ts
+++ b/tests/fixtures/delete-file-ts/tests/out-of-project.ts
@@ -1,0 +1,3 @@
+import { targetFn } from "../src/target";
+
+console.log(targetFn());

--- a/tests/fixtures/delete-file-ts/tsconfig.json
+++ b/tests/fixtures/delete-file-ts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": { "strict": true },
+  "include": ["src/**/*.ts"]
+}

--- a/tests/operations/deleteFile.test.ts
+++ b/tests/operations/deleteFile.test.ts
@@ -1,0 +1,289 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { deleteFile } from "../../src/operations/deleteFile.js";
+import { TsProvider } from "../../src/providers/ts.js";
+import { cleanup, copyFixture, fileExists, readFile } from "../helpers.js";
+
+describe("deleteFile", () => {
+  const dirs: string[] = [];
+  afterEach(() => dirs.splice(0).forEach(cleanup));
+
+  describe("in-project TS/JS files", () => {
+    it("removes named import declarations that reference the deleted file", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      const result = await deleteFile(new TsProvider(), `${dir}/src/target.ts`, dir);
+
+      expect(result.filesModified).toContain(`${dir}/src/importer.ts`);
+      expect(readFile(dir, "src/importer.ts")).not.toMatch(/from ['"]\.\/target['"]/);
+    });
+
+    it("removes type-only import declarations that reference the deleted file", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      await deleteFile(new TsProvider(), `${dir}/src/target.ts`, dir);
+
+      // importer.ts has both a named import and a type-only import from target
+      const content = readFile(dir, "src/importer.ts");
+      expect(content).not.toMatch(/import type.*from ['"]\.\/target['"]/);
+    });
+
+    it("removes export * and named re-export declarations from barrel files", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      const result = await deleteFile(new TsProvider(), `${dir}/src/target.ts`, dir);
+
+      expect(result.filesModified).toContain(`${dir}/src/barrel.ts`);
+      const content = readFile(dir, "src/barrel.ts");
+      expect(content).not.toMatch(/from ['"]\.\/target['"]/);
+    });
+
+    it("counts every removed declaration in importRefsRemoved", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      // importer.ts: 2 decls (named import + type import)
+      // barrel.ts:   2 decls (export * + named re-export)
+      // tests/out-of-project.ts: 1 decl (out-of-project, but still within workspace)
+      const result = await deleteFile(new TsProvider(), `${dir}/src/target.ts`, dir);
+
+      expect(result.importRefsRemoved).toBe(5);
+    });
+
+    it("does not include the deleted file itself in filesModified", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      const result = await deleteFile(new TsProvider(), `${dir}/src/target.ts`, dir);
+
+      expect(result.filesModified).not.toContain(`${dir}/src/target.ts`);
+    });
+
+    it("returns importRefsRemoved = 0 and empty filesModified when nothing imports the file", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      const isolated = path.join(dir, "src", "isolated.ts");
+      fs.writeFileSync(isolated, "export const x = 1;\n", "utf8");
+
+      const result = await deleteFile(new TsProvider(), isolated, dir);
+
+      expect(result.importRefsRemoved).toBe(0);
+      expect(result.filesModified).toHaveLength(0);
+    });
+  });
+
+  describe("physical deletion", () => {
+    it("removes the target file from disk after cleaning importers", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      expect(fileExists(dir, "src/target.ts")).toBe(true);
+      const result = await deleteFile(new TsProvider(), `${dir}/src/target.ts`, dir);
+
+      expect(fileExists(dir, "src/target.ts")).toBe(false);
+      expect(result.deletedFile).toBe(`${dir}/src/target.ts`);
+    });
+
+    it("deletes the file even when it has no importers", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      const isolated = path.join(dir, "src", "isolated.ts");
+      fs.writeFileSync(isolated, "export const x = 1;\n", "utf8");
+
+      await deleteFile(new TsProvider(), isolated, dir);
+
+      expect(fs.existsSync(isolated)).toBe(false);
+    });
+  });
+
+  describe("out-of-project TS/JS files", () => {
+    it("removes imports from files not included in tsconfig", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      // tests/out-of-project.ts is outside tsconfig include (src/**/*.ts)
+      const result = await deleteFile(new TsProvider(), `${dir}/src/target.ts`, dir);
+
+      expect(result.filesModified).toContain(`${dir}/tests/out-of-project.ts`);
+      expect(readFile(dir, "tests/out-of-project.ts")).not.toMatch(/from ['"][^'"]*target['"]/);
+    });
+
+    it("handles imports that use an explicit file extension", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      const extra = path.join(dir, "tests", "explicit-ext.ts");
+      fs.writeFileSync(
+        extra,
+        'import { targetFn } from "../src/target.ts";\nconst _ = targetFn();\n',
+        "utf8",
+      );
+
+      const result = await deleteFile(new TsProvider(), `${dir}/src/target.ts`, dir);
+
+      expect(result.filesModified).toContain(extra);
+      expect(fs.readFileSync(extra, "utf8")).not.toMatch(/from ['"][^'"]*target/);
+    });
+  });
+
+  describe("Vue SFC script blocks", () => {
+    it("removes named and type-only import lines from script blocks", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      const vueFile = path.join(dir, "src", "Comp.vue");
+      fs.writeFileSync(
+        vueFile,
+        [
+          '<script setup lang="ts">',
+          "import { targetFn } from './target';",
+          "import type { TargetType } from './target';",
+          "import * as All from './target';",
+          "const x = targetFn();",
+          "</script>",
+          "<template><div>hello</div></template>",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const result = await deleteFile(new TsProvider(), `${dir}/src/target.ts`, dir);
+
+      expect(result.filesModified).toContain(vueFile);
+      const content = fs.readFileSync(vueFile, "utf8");
+      expect(content).not.toMatch(/from ['"]\.\/target['"]/);
+      // Non-import content is preserved
+      expect(content).toContain("const x = targetFn();");
+      expect(content).toContain("<template>");
+    });
+
+    it("removes bare side-effect import lines from script blocks", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      const vueFile = path.join(dir, "src", "SideEffect.vue");
+      fs.writeFileSync(
+        vueFile,
+        ["<script setup>", "import './target';", "const x = 1;", "</script>"].join("\n"),
+        "utf8",
+      );
+
+      const result = await deleteFile(new TsProvider(), `${dir}/src/target.ts`, dir);
+
+      expect(result.filesModified).toContain(vueFile);
+      const content = fs.readFileSync(vueFile, "utf8");
+      expect(content).not.toContain("import './target'");
+      expect(content).toContain("const x = 1;");
+    });
+
+    it("removes re-export lines from script blocks", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      const vueFile = path.join(dir, "src", "ReExport.vue");
+      fs.writeFileSync(
+        vueFile,
+        [
+          "<script>",
+          "export * from './target';",
+          "export { targetFn } from './target';",
+          "</script>",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const result = await deleteFile(new TsProvider(), `${dir}/src/target.ts`, dir);
+
+      expect(result.filesModified).toContain(vueFile);
+      expect(fs.readFileSync(vueFile, "utf8")).not.toMatch(/from ['"]\.\/target['"]/);
+    });
+
+    it("does not modify Vue files that do not import the deleted file", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      const originalContent = [
+        "<script setup>",
+        "import { other } from './other-module';",
+        "const x = 1;",
+        "</script>",
+      ].join("\n");
+      const vueFile = path.join(dir, "src", "Unrelated.vue");
+      fs.writeFileSync(vueFile, originalContent, "utf8");
+
+      await deleteFile(new TsProvider(), `${dir}/src/target.ts`, dir);
+
+      expect(fs.readFileSync(vueFile, "utf8")).toBe(originalContent);
+    });
+
+    it("does not remove side-effect imports from paths other than the deleted file", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      const originalContent = [
+        "<script setup>",
+        "import './other-module';",
+        "const x = 1;",
+        "</script>",
+      ].join("\n");
+      const vueFile = path.join(dir, "src", "OtherSideEffect.vue");
+      fs.writeFileSync(vueFile, originalContent, "utf8");
+
+      await deleteFile(new TsProvider(), `${dir}/src/target.ts`, dir);
+
+      expect(fs.readFileSync(vueFile, "utf8")).toBe(originalContent);
+    });
+  });
+
+  describe("workspace boundary", () => {
+    it("skips out-of-workspace importers and reports them in filesSkipped without writing", async () => {
+      // cross-boundary fixture: tsconfig includes ../consumer/**/* so ts-morph's
+      // in-project scan finds consumer/main.ts, which is outside the workspace.
+      const root = copyFixture("cross-boundary");
+      dirs.push(root);
+
+      const workspace = path.join(root, "workspace");
+      const targetFile = path.join(workspace, "src", "utils.ts");
+      const consumerFile = path.join(root, "consumer", "main.ts");
+      const consumerBefore = fs.readFileSync(consumerFile, "utf8");
+
+      const result = await deleteFile(new TsProvider(), targetFile, workspace);
+
+      // consumer/main.ts is outside workspace — must not be written
+      expect(fs.readFileSync(consumerFile, "utf8")).toBe(consumerBefore);
+      // It must appear in filesSkipped
+      expect(result.filesSkipped).toContain(consumerFile);
+      // The target file is gone
+      expect(fs.existsSync(targetFile)).toBe(false);
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws a structured FILE_NOT_FOUND error when the target does not exist", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      await expect(
+        deleteFile(new TsProvider(), `${dir}/src/does-not-exist.ts`, dir),
+      ).rejects.toMatchObject({ code: "FILE_NOT_FOUND" });
+    });
+
+    it("does not touch any other files when the target is missing", async () => {
+      const dir = copyFixture("delete-file-ts");
+      dirs.push(dir);
+
+      const importerBefore = readFile(dir, "src/importer.ts");
+
+      await expect(
+        deleteFile(new TsProvider(), `${dir}/src/missing.ts`, dir),
+      ).rejects.toMatchObject({ code: "FILE_NOT_FOUND" });
+
+      expect(readFile(dir, "src/importer.ts")).toBe(importerBefore);
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implement the `deleteFile` operation to remove files and automatically clean up all references across TS/JS and Vue SFCs.

The PR also includes an update to the slice skill (`SKILL.md`) with a concrete example for test naming conventions. This change addresses a previous issue where spec acceptance criteria (AC) numbers were used in test labels, which couples tests to ephemeral spec identifiers rather than describing stable behavior. The new example guides agents to use a `capability / logical grouping / behavior` structure for `describe` and `it` blocks.

---
<p><a href="https://cursor.com/agents/bc-71f2be3f-8d7a-4ff6-b973-5d3ec4876abd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71f2be3f-8d7a-4ff6-b973-5d3ec4876abd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->