### PR TITLE
Cli artifact permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "./dist/cli.js",
   "scripts": {
-    "build": "rm -rf dist && tsc",
+    "build": "rm -rf dist && tsc && chmod +x dist/cli.js",
     "dev": "tsx src/cli.ts",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -26,7 +26,7 @@
     "test:mutate": "rm -rf .stryker-tmp && stryker run",
     "eval": "tsx eval/run-eval.ts",
     "check": "biome check . && pnpm build && pnpm test",
-    "prepare": "tsc",
+    "prepare": "tsc && chmod +x dist/cli.js",
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add execute permissions to `dist/cli.js` in build scripts to ensure the CLI is runnable after installation.

The `tsc` compiler does not automatically set execute permissions on its output files. This meant that `dist/cli.js`, despite having a shebang in its source, was generated with `644` permissions, preventing it from being directly executed when installed locally or via `npm`/`pnpm`'s `bin` entry. Explicitly adding `chmod +x dist/cli.js` to the `build` and `prepare` scripts resolves this by ensuring the file has `755` permissions.

---
<p><a href="https://cursor.com/agents/bc-1c144b40-3da4-4865-847b-5cb882f548fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c144b40-3da4-4865-847b-5cb882f548fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->