### PR TITLE
docs(skill): note that move-symbol auto-creates destFile; remove stale handoff entry

### DIFF
--- a/.claude/skills/move-and-rename/SKILL.md
+++ b/.claude/skills/move-and-rename/SKILL.md
@@ -37,7 +37,7 @@ Relocates all files and rewrites every nested import path.
 weaver move-symbol '{"sourceFile": "src/a.ts", "symbolName": "Foo", "destFile": "src/b.ts"}'
 ```
 
-Moves the declaration and updates every importer. Check `typeErrors` after each move.
+Moves the declaration and updates every importer. `destFile` is created automatically if it does not exist — no need to pre-create it. Check `typeErrors` after each move.
 
 ## Delete a file safely
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -157,7 +157,6 @@ Priorities run top to bottom. Complete a tier before starting the next.
 
 ### P2 — High-value features / bugs / tech debt
 
-- **`moveSymbol` auto-create destination file** `[needs design]` — if the destination file does not exist, `moveSymbol` fails. Callers must pre-create the file (e.g. with `export {};`) before moving symbols into it. Trivial fix: create the file automatically if it doesn't exist. Discovered during the `types.ts` decomposition.
 - **Agent guidance on type errors in tool responses** `[needs design]` — all write operations return `typeErrors`; agents need to know this is an action item (something wasn't fully updated) and follow up with `replaceText`. Currently nothing teaches this pattern. Decision needed: shipped skill file, tool description addition, CLAUDE.md guidance snippet, or combination?
 
 ---


### PR DESCRIPTION
The implementation already creates the destination file when it does not
exist. Update the shipped skill file so agents know they do not need to
pre-create stub files before calling move-symbol.

https://claude.ai/code/session_018LU1omHsSTbmmSK7UnApXp