### PR TITLE
docs: introduce [chore] tag for tasks that need no spec

### DIFF
--- a/.claude/skills/move-and-rename/SKILL.md
+++ b/.claude/skills/move-and-rename/SKILL.md
@@ -63,9 +63,21 @@ All write operations return:
 
 - **`filesModified`** — every file changed. Don't read these to verify; the list is exhaustive.
 - **`filesSkipped`** — files outside workspace that need manual attention.
-- **`typeErrors`** — type errors after the change. These are action items — fix with `replace-text`.
+- **`typeErrors`** / **`typeErrorCount`** / **`typeErrorsTruncated`** — type errors in modified files. See below.
 
 Pass `"checkTypeErrors": false` when batching changes to check errors once at the end.
+
+## When the response has type errors
+
+`status: "warn"` means `typeErrors` is non-empty. These are action items — something wasn't fully updated and the codebase won't compile until they're fixed.
+
+Follow-up workflow:
+
+1. Examine each entry — `file`, `line`, `col`, and `message` identify exactly what broke.
+2. Call `replace-text` with surgical edits to fix each broken reference.
+3. Call `get-type-errors` on the modified files to confirm clean.
+
+When `typeErrorsTruncated: true`, only the first 100 of `typeErrorCount` total errors appear. Call `get-type-errors` with a specific file path to see the full set before fixing.
 
 ## When NOT to use
 

--- a/.claude/skills/move-and-rename/SKILL.md
+++ b/.claude/skills/move-and-rename/SKILL.md
@@ -63,21 +63,9 @@ All write operations return:
 
 - **`filesModified`** — every file changed. Don't read these to verify; the list is exhaustive.
 - **`filesSkipped`** — files outside workspace that need manual attention.
-- **`typeErrors`** / **`typeErrorCount`** / **`typeErrorsTruncated`** — type errors in modified files. See below.
+- **`typeErrors`** / **`typeErrorCount`** / **`typeErrorsTruncated`** — type errors in files modified by the operation. `status: "warn"` means `typeErrors` is non-empty. Each entry has `file`, `line`, `col`, and `message`. When `typeErrorsTruncated: true`, only the first 100 of `typeErrorCount` total errors are returned; call `get-type-errors` with a specific file path to retrieve the full set.
 
 Pass `"checkTypeErrors": false` when batching changes to check errors once at the end.
-
-## When the response has type errors
-
-`status: "warn"` means `typeErrors` is non-empty. These are action items — something wasn't fully updated and the codebase won't compile until they're fixed.
-
-Follow-up workflow:
-
-1. Examine each entry — `file`, `line`, `col`, and `message` identify exactly what broke.
-2. Call `replace-text` with surgical edits to fix each broken reference.
-3. Call `get-type-errors` on the modified files to confirm clean.
-
-When `typeErrorsTruncated: true`, only the first 100 of `typeErrorCount` total errors appear. Call `get-type-errors` with a specific file path to see the full set before fixing.
 
 ## When NOT to use
 

--- a/.claude/skills/search-and-replace/SKILL.md
+++ b/.claude/skills/search-and-replace/SKILL.md
@@ -22,7 +22,7 @@ Returns structured results: `{file, line, col, matchText}` for every hit. Use th
 weaver replace-text '{"pattern": "oldName", "replacement": "newName", "glob": "**/*.ts"}'
 ```
 
-Response includes `filesModified`, `replacementCount`, and `typeErrors`. Check `typeErrors` — they tell you if the replacement broke something.
+Response includes `filesModified`, `replacementCount`, and `typeErrors`. If `status` is `warn`, `typeErrors` are action items — see below.
 
 ## Surgical mode: replace at exact positions
 
@@ -46,8 +46,22 @@ weaver search-text '{"pattern": "FOO", "glob": "**/*.ts"}'
 # 2. Replace all (or use surgical mode for selective replacement)
 weaver replace-text '{"pattern": "FOO", "replacement": "BAR", "glob": "**/*.ts"}'
 
-# 3. Check typeErrors in the response — fix any issues
+# 3. If status is "warn", fix typeErrors with replace-text, then verify with get-type-errors
 ```
+
+## When the response has type errors
+
+`status: "warn"` means `typeErrors` is non-empty. These are action items — the replacement left broken references that won't compile.
+
+Follow-up workflow:
+
+1. Examine each entry — `file`, `line`, `col`, and `message` identify exactly what broke.
+2. Call `replace-text` with surgical edits to fix each broken reference.
+3. Call `get-type-errors` on the modified files to confirm clean.
+
+When `typeErrorsTruncated: true`, only the first 100 of `typeErrorCount` total errors appear. Call `get-type-errors` with a specific file path to see the full set before fixing.
+
+Pass `"checkTypeErrors": false` when batching multiple replace calls to check errors once at the end.
 
 ## Scoping: `workspace` vs `glob`
 

--- a/.claude/skills/search-and-replace/SKILL.md
+++ b/.claude/skills/search-and-replace/SKILL.md
@@ -22,7 +22,7 @@ Returns structured results: `{file, line, col, matchText}` for every hit. Use th
 weaver replace-text '{"pattern": "oldName", "replacement": "newName", "glob": "**/*.ts"}'
 ```
 
-Response includes `filesModified`, `replacementCount`, and `typeErrors`. If `status` is `warn`, `typeErrors` are action items — see below.
+Response includes `filesModified`, `replacementCount`, and `typeErrors`. `status: "warn"` means `typeErrors` is non-empty — each entry has `file`, `line`, `col`, and `message`.
 
 ## Surgical mode: replace at exact positions
 
@@ -45,23 +45,9 @@ weaver search-text '{"pattern": "FOO", "glob": "**/*.ts"}'
 
 # 2. Replace all (or use surgical mode for selective replacement)
 weaver replace-text '{"pattern": "FOO", "replacement": "BAR", "glob": "**/*.ts"}'
-
-# 3. If status is "warn", fix typeErrors with replace-text, then verify with get-type-errors
 ```
 
-## When the response has type errors
-
-`status: "warn"` means `typeErrors` is non-empty. These are action items — the replacement left broken references that won't compile.
-
-Follow-up workflow:
-
-1. Examine each entry — `file`, `line`, `col`, and `message` identify exactly what broke.
-2. Call `replace-text` with surgical edits to fix each broken reference.
-3. Call `get-type-errors` on the modified files to confirm clean.
-
-When `typeErrorsTruncated: true`, only the first 100 of `typeErrorCount` total errors appear. Call `get-type-errors` with a specific file path to see the full set before fixing.
-
-Pass `"checkTypeErrors": false` when batching multiple replace calls to check errors once at the end.
+Pass `"checkTypeErrors": false` when batching multiple replace calls to check errors once at the end. When `typeErrorsTruncated: true`, only the first 100 of `typeErrorCount` total errors are returned; call `get-type-errors` with a specific file path to retrieve the full set.
 
 ## Scoping: `workspace` vs `glob`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,16 @@ Finish the test for a unit before moving to the next. The test is part of the im
 **Rule 8: Write durable memory to `.claude/MEMORY.md` — never to `~/.claude/`.**
 This project runs in a dev container. The home directory is deleted on every rebuild, taking `~/.claude/projects/` with it. Do NOT use the auto-memory system there. Use `.claude/MEMORY.md` (git-tracked) instead. Technical gotchas belong in the relevant `docs/features/` or `docs/tech/` doc, not in MEMORY.md.
 
-**Rule 10: Every task gets a spec before implementation.**
-Tasks in `docs/handoff.md` are either `[needs design]` (no spec yet) or linked to a spec file in `docs/specs/`. Use `/spec` to create a spec from a `[needs design]` entry — it picks the right template, walks through ACs with the user, and produces a ready-to-implement file. Use `/slice` to implement a spec. When adding new work discovered during a session, add a `[needs design]` entry to handoff.md and move on — do not spec it in the same session. Do not add ACs to feature docs (`docs/features/*.md`) — those are reference docs for shipped behaviour, not task tracking. ACs live in spec files and are archived (with an Outcome section) when the task ships.
+**Rule 10: Not every task needs a spec — but every task needs a tag.**
+Tasks in `docs/handoff.md` carry one of three tags:
+
+- **`[chore]`** — implementation is unambiguous; implement directly, no spec needed. Any decision context is in the task description itself. Use for: text/doc edits, dependency bumps, dead code removal, small config changes. If you find yourself unsure how to implement it, change the tag to `[needs design]`.
+- **`[needs design]`** — problem understood, solution not agreed. Run `/spec` first — it picks the right template, walks through ACs with the user, and produces a ready-to-implement file. When adding new work discovered during a session, add a `[needs design]` entry and move on — do not spec it in the same session.
+- **spec link** — already designed, run `/slice` to implement.
+
+Before writing a spec, ask: (1) does planning add safety? (real architectural choices, multiple code paths, meaningful risk) and (2) will an archived spec be a useful future reference? (the "why" isn't visible in the output itself). If neither is true, use `[chore]`.
+
+Do not add ACs to feature docs (`docs/features/*.md`) — those are reference docs for shipped behaviour, not task tracking. ACs live in spec files and are archived (with an Outcome section) when the task ships.
 
 Specs are **changesets**, not features. They describe a unit of work to deliver, then get archived. Code and tests must never reference spec identifiers (AC numbers, spec slugs, etc.) — describe the *behaviour* being tested, not the changeset that introduced it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ Use the CLI (`pnpm exec weaver <command>`) for refactoring during development. T
 
 The shipped skill files at `.claude/skills/{search-and-replace,move-and-rename,code-inspection}/SKILL.md` are the canonical refactoring guidance — the same files external users load.
 
+Skill files are interface documentation, not agent playbooks. Describe what the tool returns and what each field means. Do not prescribe what the agent should do in response — that's the caller's policy, not the tool's contract. The agent has project context weaver doesn't: pre-existing errors, intent, conventions.
+
 **Rule 11: Pin exact dependency versions. Never use `^` or `~` ranges.**
 Ranges let a compromised patch release auto-install on the next `pnpm install`, turning a single package takeover into a supply-chain attack across every consumer. All versions in `package.json` must be exact (e.g. `"1.2.3"`, not `"^1.2.3"`). Only install actively maintained packages — check for deprecation warnings before adding a dependency.
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -158,8 +158,6 @@ Priorities run top to bottom. Complete a tier before starting the next.
 
 ### P2 — High-value features / bugs / tech debt
 
-- **Agent guidance on type errors in tool responses** `[chore]` — all write operations return `typeErrors`; agents need to know this is an action item (something wasn't fully updated) and follow up with `replace-text`. Update: (1) each write-op tool description in `src/adapters/mcp/tools.ts` to state that `status: "warn"` means `typeErrors` are action items requiring `replace-text` follow-up; (2) `move-and-rename/SKILL.md` and `search-and-replace/SKILL.md` with a "When the response has type errors" section covering the full workflow and truncation case. Not in CLAUDE.md — external agents won't see it.
-
 ---
 
 ### P3 — Medium-value features / bugs / tech debt

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -19,9 +19,10 @@ Context that isn't in the feature docs — things you need to know before pickin
 5. [`docs/architecture.md`](architecture.md) — compiler/operation architecture; read before touching anything in `src/`
 6. [`docs/quality.md`](quality.md) — testing and reliability expectations
 
-**Picking up a task?** Tasks have one of two states:
-- **Has a spec link** → ready to implement. Read the spec, then run `/slice`.
+**Picking up a task?** Tasks have one of three states:
+- **`[chore]`** → implementation is unambiguous; implement directly, no spec needed. Any decision context is in the task description.
 - **`[needs design]`** → problem understood, solution not yet agreed. Run `/spec` to create a spec with the user before writing code.
+- **Has a spec link** → already designed. Read the spec, then run `/slice`.
 
 An agent discovering new work should add a `[needs design]` entry and move on — do not design it in the same session.
 
@@ -157,7 +158,7 @@ Priorities run top to bottom. Complete a tier before starting the next.
 
 ### P2 — High-value features / bugs / tech debt
 
-- **Agent guidance on type errors in tool responses** `[needs design]` — all write operations return `typeErrors`; agents need to know this is an action item (something wasn't fully updated) and follow up with `replaceText`. Currently nothing teaches this pattern. Decision needed: shipped skill file, tool description addition, CLAUDE.md guidance snippet, or combination?
+- **Agent guidance on type errors in tool responses** `[chore]` — all write operations return `typeErrors`; agents need to know this is an action item (something wasn't fully updated) and follow up with `replace-text`. Update: (1) each write-op tool description in `src/adapters/mcp/tools.ts` to state that `status: "warn"` means `typeErrors` are action items requiring `replace-text` follow-up; (2) `move-and-rename/SKILL.md` and `search-and-replace/SKILL.md` with a "When the response has type errors" section covering the full workflow and truncation case. Not in CLAUDE.md — external agents won't see it.
 
 ---
 

--- a/src/adapters/mcp/mcp.ts
+++ b/src/adapters/mcp/mcp.ts
@@ -58,7 +58,12 @@ async function startMcpServer(absWorkspace: string): Promise<void> {
         "tool calls are fast and use far fewer tokens than reading files to trace dependencies manually. " +
         "These tools use the compiler's reference graph, which tracks dependencies through " +
         "re-exports, barrel files, type-only imports, and Vue SFCs that text-based approaches miss. " +
-        "If any tool returns error DAEMON_STARTING, the project graph is still loading — retry after a short delay.",
+        "If any tool returns error DAEMON_STARTING, the project graph is still loading — retry after a short delay. " +
+        "Write operations return typeErrors (array), typeErrorCount, and typeErrorsTruncated. " +
+        "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
+        "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; " +
+        "call get-type-errors on a specific file to retrieve the full set. " +
+        "Pass checkTypeErrors:false to suppress.",
     },
   );
 

--- a/src/adapters/mcp/tools.ts
+++ b/src/adapters/mcp/tools.ts
@@ -30,9 +30,7 @@ export const TOOLS: ToolDefinition[] = [
       "When renaming an identifier, use this to update every reference project-wide. " +
       "Scope-aware — won't touch unrelated identifiers that share the same name in other scopes. " +
       "Returns filesModified (no need to read them to verify) and filesSkipped (outside workspace, not written — surface to user). " +
-      "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
-      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; call get-type-errors on a specific file to retrieve the full set. " +
-      "Pass checkTypeErrors:false to suppress.",
+      "Pass checkTypeErrors:false to suppress the post-write type check.",
     inputSchema: {
       file: RenameArgsSchema.shape.file.describe("Absolute path to the file"),
       line: RenameArgsSchema.shape.line.describe("Line number (1-based)"),
@@ -52,9 +50,7 @@ export const TOOLS: ToolDefinition[] = [
       "The selection must cover complete statements — endCol must point at the last character " +
       "of the last statement (the `;` if present, or the last token in no-semi style). " +
       ".ts/.tsx only; returns NOT_SUPPORTED for .vue files. " +
-      "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
-      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; call get-type-errors on a specific file to retrieve the full set. " +
-      "Pass checkTypeErrors:false to suppress.",
+      "Pass checkTypeErrors:false to suppress the post-write type check.",
     inputSchema: {
       file: ExtractFunctionArgsSchema.shape.file.describe(
         "Absolute path to the .ts or .tsx file containing the code to extract",
@@ -85,9 +81,7 @@ export const TOOLS: ToolDefinition[] = [
       "When relocating a file, use this instead of shell mv — it rewrites every import that references the file, project-wide. " +
       "Creates the destination directory if needed. Works for non-source files (tests, scripts, config) too. " +
       "Returns filesModified and filesSkipped (outside workspace, not written — surface to user). " +
-      "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
-      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; call get-type-errors on a specific file to retrieve the full set. " +
-      "Pass checkTypeErrors:false to suppress.",
+      "Pass checkTypeErrors:false to suppress the post-write type check.",
     inputSchema: {
       oldPath: MoveArgsSchema.shape.oldPath.describe("Absolute path to the file to move"),
       newPath: MoveArgsSchema.shape.newPath.describe("Absolute destination path"),
@@ -103,9 +97,7 @@ export const TOOLS: ToolDefinition[] = [
       "Handles nested subdirectories, preserves internal structure, and updates all external references. " +
       "Use this instead of multiple moveFile calls when relocating a folder. " +
       "Returns filesMoved (files that were relocated), filesModified (all files with rewritten imports, including the moved files), and filesSkipped (outside workspace, not written). " +
-      "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
-      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; call get-type-errors on a specific file to retrieve the full set. " +
-      "Pass checkTypeErrors:false to suppress.",
+      "Pass checkTypeErrors:false to suppress the post-write type check.",
     inputSchema: {
       oldPath: MoveDirectoryArgsSchema.shape.oldPath.describe(
         "Absolute path to the source directory",
@@ -129,9 +121,7 @@ export const TOOLS: ToolDefinition[] = [
       "Only top-level exported declarations (export function, export const, export class, etc.); " +
       "does not support class methods or re-exports via `export { }`. " +
       "Returns filesModified and filesSkipped (outside workspace, not written — surface to user). " +
-      "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
-      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; call get-type-errors on a specific file to retrieve the full set. " +
-      "Pass checkTypeErrors:false to suppress.",
+      "Pass checkTypeErrors:false to suppress the post-write type check.",
     inputSchema: {
       sourceFile: MoveSymbolArgsSchema.shape.sourceFile.describe(
         "Absolute path to the file containing the symbol",
@@ -156,9 +146,7 @@ export const TOOLS: ToolDefinition[] = [
       "When deleting a file, use this instead of shell rm — it removes every import and re-export of the file from other project files before deleting it. " +
       "Covers in-project source files, out-of-project files (tests, scripts), and Vue SFC script blocks. " +
       "Returns deletedFile (echo of the path deleted), filesModified (imports cleaned), filesSkipped (outside workspace, not written — surface to user), and importRefsRemoved. " +
-      "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
-      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; call get-type-errors on a specific file to retrieve the full set. " +
-      "Pass checkTypeErrors:false to suppress.",
+      "Pass checkTypeErrors:false to suppress the post-write type check.",
     inputSchema: {
       file: DeleteFileArgsSchema.shape.file.describe(
         "Absolute path to the .ts, .tsx, .js, .jsx, or .vue file to delete",
@@ -249,9 +237,7 @@ export const TOOLS: ToolDefinition[] = [
       "(2) Surgical mode — 'edits' array of {file, line, col, oldText, newText} for exact position-verified replacements; " +
       "run searchText first to locate targets and get coordinates; oldText is checked before writing, so stale edits fail rather than corrupt. " +
       "Both modes skip sensitive files. Returns filesModified and replacementCount. " +
-      "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
-      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; call get-type-errors on a specific file to retrieve the full set. " +
-      "Pass checkTypeErrors:false to suppress.",
+      "Pass checkTypeErrors:false to suppress the post-write type check.",
     inputSchema: {
       pattern: ReplaceTextBaseSchema.shape.pattern.describe(
         "Regex pattern to replace (pattern mode)",

--- a/src/adapters/mcp/tools.ts
+++ b/src/adapters/mcp/tools.ts
@@ -30,8 +30,8 @@ export const TOOLS: ToolDefinition[] = [
       "When renaming an identifier, use this to update every reference project-wide. " +
       "Scope-aware — won't touch unrelated identifiers that share the same name in other scopes. " +
       "Returns filesModified (no need to read them to verify) and filesSkipped (outside workspace, not written — surface to user). " +
-      "If status is 'warn', typeErrors are action items — each is a broken reference; fix with replace-text before moving on. " +
-      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors appear; call get-type-errors on a specific file to see the rest. " +
+      "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
+      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; call get-type-errors on a specific file to retrieve the full set. " +
       "Pass checkTypeErrors:false to suppress.",
     inputSchema: {
       file: RenameArgsSchema.shape.file.describe("Absolute path to the file"),
@@ -52,8 +52,8 @@ export const TOOLS: ToolDefinition[] = [
       "The selection must cover complete statements — endCol must point at the last character " +
       "of the last statement (the `;` if present, or the last token in no-semi style). " +
       ".ts/.tsx only; returns NOT_SUPPORTED for .vue files. " +
-      "If status is 'warn', typeErrors are action items — each is a broken reference; fix with replace-text before moving on. " +
-      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors appear; call get-type-errors on a specific file to see the rest. " +
+      "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
+      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; call get-type-errors on a specific file to retrieve the full set. " +
       "Pass checkTypeErrors:false to suppress.",
     inputSchema: {
       file: ExtractFunctionArgsSchema.shape.file.describe(
@@ -85,8 +85,8 @@ export const TOOLS: ToolDefinition[] = [
       "When relocating a file, use this instead of shell mv — it rewrites every import that references the file, project-wide. " +
       "Creates the destination directory if needed. Works for non-source files (tests, scripts, config) too. " +
       "Returns filesModified and filesSkipped (outside workspace, not written — surface to user). " +
-      "If status is 'warn', typeErrors are action items — each is a broken reference; fix with replace-text before moving on. " +
-      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors appear; call get-type-errors on a specific file to see the rest. " +
+      "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
+      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; call get-type-errors on a specific file to retrieve the full set. " +
       "Pass checkTypeErrors:false to suppress.",
     inputSchema: {
       oldPath: MoveArgsSchema.shape.oldPath.describe("Absolute path to the file to move"),
@@ -103,8 +103,8 @@ export const TOOLS: ToolDefinition[] = [
       "Handles nested subdirectories, preserves internal structure, and updates all external references. " +
       "Use this instead of multiple moveFile calls when relocating a folder. " +
       "Returns filesMoved (files that were relocated), filesModified (all files with rewritten imports, including the moved files), and filesSkipped (outside workspace, not written). " +
-      "If status is 'warn', typeErrors are action items — each is a broken reference; fix with replace-text before moving on. " +
-      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors appear; call get-type-errors on a specific file to see the rest. " +
+      "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
+      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; call get-type-errors on a specific file to retrieve the full set. " +
       "Pass checkTypeErrors:false to suppress.",
     inputSchema: {
       oldPath: MoveDirectoryArgsSchema.shape.oldPath.describe(
@@ -129,8 +129,8 @@ export const TOOLS: ToolDefinition[] = [
       "Only top-level exported declarations (export function, export const, export class, etc.); " +
       "does not support class methods or re-exports via `export { }`. " +
       "Returns filesModified and filesSkipped (outside workspace, not written — surface to user). " +
-      "If status is 'warn', typeErrors are action items — each is a broken reference; fix with replace-text before moving on. " +
-      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors appear; call get-type-errors on a specific file to see the rest. " +
+      "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
+      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; call get-type-errors on a specific file to retrieve the full set. " +
       "Pass checkTypeErrors:false to suppress.",
     inputSchema: {
       sourceFile: MoveSymbolArgsSchema.shape.sourceFile.describe(
@@ -156,8 +156,8 @@ export const TOOLS: ToolDefinition[] = [
       "When deleting a file, use this instead of shell rm — it removes every import and re-export of the file from other project files before deleting it. " +
       "Covers in-project source files, out-of-project files (tests, scripts), and Vue SFC script blocks. " +
       "Returns deletedFile (echo of the path deleted), filesModified (imports cleaned), filesSkipped (outside workspace, not written — surface to user), and importRefsRemoved. " +
-      "If status is 'warn', typeErrors are action items — each is a broken reference; fix with replace-text before moving on. " +
-      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors appear; call get-type-errors on a specific file to see the rest. " +
+      "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
+      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; call get-type-errors on a specific file to retrieve the full set. " +
       "Pass checkTypeErrors:false to suppress.",
     inputSchema: {
       file: DeleteFileArgsSchema.shape.file.describe(
@@ -249,8 +249,8 @@ export const TOOLS: ToolDefinition[] = [
       "(2) Surgical mode — 'edits' array of {file, line, col, oldText, newText} for exact position-verified replacements; " +
       "run searchText first to locate targets and get coordinates; oldText is checked before writing, so stale edits fail rather than corrupt. " +
       "Both modes skip sensitive files. Returns filesModified and replacementCount. " +
-      "If status is 'warn', typeErrors are action items — each is a broken reference; fix with another replace-text call before moving on. " +
-      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors appear; call get-type-errors on a specific file to see the rest. " +
+      "status:'warn' means typeErrors is non-empty — type errors in the modified files. " +
+      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors are returned; call get-type-errors on a specific file to retrieve the full set. " +
       "Pass checkTypeErrors:false to suppress.",
     inputSchema: {
       pattern: ReplaceTextBaseSchema.shape.pattern.describe(

--- a/src/adapters/mcp/tools.ts
+++ b/src/adapters/mcp/tools.ts
@@ -30,7 +30,9 @@ export const TOOLS: ToolDefinition[] = [
       "When renaming an identifier, use this to update every reference project-wide. " +
       "Scope-aware — won't touch unrelated identifiers that share the same name in other scopes. " +
       "Returns filesModified (no need to read them to verify) and filesSkipped (outside workspace, not written — surface to user). " +
-      "Type errors in modified files are returned automatically (typeErrors, typeErrorCount, typeErrorsTruncated); pass checkTypeErrors:false to suppress.",
+      "If status is 'warn', typeErrors are action items — each is a broken reference; fix with replace-text before moving on. " +
+      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors appear; call get-type-errors on a specific file to see the rest. " +
+      "Pass checkTypeErrors:false to suppress.",
     inputSchema: {
       file: RenameArgsSchema.shape.file.describe("Absolute path to the file"),
       line: RenameArgsSchema.shape.line.describe("Line number (1-based)"),
@@ -50,7 +52,9 @@ export const TOOLS: ToolDefinition[] = [
       "The selection must cover complete statements — endCol must point at the last character " +
       "of the last statement (the `;` if present, or the last token in no-semi style). " +
       ".ts/.tsx only; returns NOT_SUPPORTED for .vue files. " +
-      "Type errors in the modified file are returned automatically (typeErrors, typeErrorCount, typeErrorsTruncated); pass checkTypeErrors:false to suppress.",
+      "If status is 'warn', typeErrors are action items — each is a broken reference; fix with replace-text before moving on. " +
+      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors appear; call get-type-errors on a specific file to see the rest. " +
+      "Pass checkTypeErrors:false to suppress.",
     inputSchema: {
       file: ExtractFunctionArgsSchema.shape.file.describe(
         "Absolute path to the .ts or .tsx file containing the code to extract",
@@ -81,7 +85,9 @@ export const TOOLS: ToolDefinition[] = [
       "When relocating a file, use this instead of shell mv — it rewrites every import that references the file, project-wide. " +
       "Creates the destination directory if needed. Works for non-source files (tests, scripts, config) too. " +
       "Returns filesModified and filesSkipped (outside workspace, not written — surface to user). " +
-      "Type errors in modified files are returned automatically (typeErrors, typeErrorCount, typeErrorsTruncated); pass checkTypeErrors:false to suppress.",
+      "If status is 'warn', typeErrors are action items — each is a broken reference; fix with replace-text before moving on. " +
+      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors appear; call get-type-errors on a specific file to see the rest. " +
+      "Pass checkTypeErrors:false to suppress.",
     inputSchema: {
       oldPath: MoveArgsSchema.shape.oldPath.describe("Absolute path to the file to move"),
       newPath: MoveArgsSchema.shape.newPath.describe("Absolute destination path"),
@@ -97,7 +103,9 @@ export const TOOLS: ToolDefinition[] = [
       "Handles nested subdirectories, preserves internal structure, and updates all external references. " +
       "Use this instead of multiple moveFile calls when relocating a folder. " +
       "Returns filesMoved (files that were relocated), filesModified (all files with rewritten imports, including the moved files), and filesSkipped (outside workspace, not written). " +
-      "Type errors in modified files are returned automatically; pass checkTypeErrors:false to suppress.",
+      "If status is 'warn', typeErrors are action items — each is a broken reference; fix with replace-text before moving on. " +
+      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors appear; call get-type-errors on a specific file to see the rest. " +
+      "Pass checkTypeErrors:false to suppress.",
     inputSchema: {
       oldPath: MoveDirectoryArgsSchema.shape.oldPath.describe(
         "Absolute path to the source directory",
@@ -121,7 +129,9 @@ export const TOOLS: ToolDefinition[] = [
       "Only top-level exported declarations (export function, export const, export class, etc.); " +
       "does not support class methods or re-exports via `export { }`. " +
       "Returns filesModified and filesSkipped (outside workspace, not written — surface to user). " +
-      "Type errors in modified files are returned automatically (typeErrors, typeErrorCount, typeErrorsTruncated); pass checkTypeErrors:false to suppress.",
+      "If status is 'warn', typeErrors are action items — each is a broken reference; fix with replace-text before moving on. " +
+      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors appear; call get-type-errors on a specific file to see the rest. " +
+      "Pass checkTypeErrors:false to suppress.",
     inputSchema: {
       sourceFile: MoveSymbolArgsSchema.shape.sourceFile.describe(
         "Absolute path to the file containing the symbol",
@@ -146,7 +156,9 @@ export const TOOLS: ToolDefinition[] = [
       "When deleting a file, use this instead of shell rm — it removes every import and re-export of the file from other project files before deleting it. " +
       "Covers in-project source files, out-of-project files (tests, scripts), and Vue SFC script blocks. " +
       "Returns deletedFile (echo of the path deleted), filesModified (imports cleaned), filesSkipped (outside workspace, not written — surface to user), and importRefsRemoved. " +
-      "Type errors in modified files are returned automatically (typeErrors, typeErrorCount, typeErrorsTruncated); pass checkTypeErrors:false to suppress.",
+      "If status is 'warn', typeErrors are action items — each is a broken reference; fix with replace-text before moving on. " +
+      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors appear; call get-type-errors on a specific file to see the rest. " +
+      "Pass checkTypeErrors:false to suppress.",
     inputSchema: {
       file: DeleteFileArgsSchema.shape.file.describe(
         "Absolute path to the .ts, .tsx, .js, .jsx, or .vue file to delete",
@@ -237,7 +249,9 @@ export const TOOLS: ToolDefinition[] = [
       "(2) Surgical mode — 'edits' array of {file, line, col, oldText, newText} for exact position-verified replacements; " +
       "run searchText first to locate targets and get coordinates; oldText is checked before writing, so stale edits fail rather than corrupt. " +
       "Both modes skip sensitive files. Returns filesModified and replacementCount. " +
-      "Type errors in modified files are returned automatically (typeErrors, typeErrorCount, typeErrorsTruncated); pass checkTypeErrors:false to suppress.",
+      "If status is 'warn', typeErrors are action items — each is a broken reference; fix with another replace-text call before moving on. " +
+      "When typeErrorsTruncated:true, only the first 100 of typeErrorCount total errors appear; call get-type-errors on a specific file to see the rest. " +
+      "Pass checkTypeErrors:false to suppress.",
     inputSchema: {
       pattern: ReplaceTextBaseSchema.shape.pattern.describe(
         "Regex pattern to replace (pattern mode)",


### PR DESCRIPTION
Adds a three-state task model to CLAUDE.md Rule 10 and handoff.md:
- [chore] — implementation unambiguous, any decision in the description
- [needs design] — run /spec first
- spec link — run /slice

Replaces the previous binary ([needs design] | spec link) which forced
the spec workflow on text-only tasks with no architectural decisions.