### PR TITLE
Fix devcontainers manager name in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,5 @@
       "description": "Keep engines.node and CI workflow node-version in sync"
     }
   ],
-  "enabledManagers": ["npm", "dockerfile", "devcontainers"]
+  "enabledManagers": ["npm", "dockerfile", "devcontainer"]
 }


### PR DESCRIPTION
## Summary
Corrected the Renovate configuration to use the proper manager name for devcontainer support.

## Changes
- Updated `enabledManagers` array in `renovate.json` to use `"devcontainer"` instead of `"devcontainers"`
  - This aligns with the correct manager identifier used by Renovate for devcontainer.json files

## Details
The devcontainer manager in Renovate uses the singular form `"devcontainer"` as its identifier. The previous configuration with the plural form `"devcontainers"` would not be recognized and could cause Renovate to skip processing devcontainer.json files.

https://claude.ai/code/session_01MeJ8DKAPmxxMDPPWSZuwC7