### PR TITLE
docs(skills): add review-changes skill and wire into slice workflow

### DIFF
--- a/.claude/skills/review-changes/SKILL.md
+++ b/.claude/skills/review-changes/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: review-changes
+description: Review changed code for reuse, quality, and efficiency, then fix any issues found.
+---
+
+# Review Changes: Code Review and Cleanup
+
+Review all changed files for reuse, quality, and efficiency. Fix any issues found.
+
+## Phase 1: Identify Changes
+
+If a commit range was passed as an argument (e.g. `/review-changes abc123..def456`), run `git diff <range>` to get the diff.
+
+Otherwise run `git diff origin/main...HEAD` to see all changes on this branch. If that returns nothing (branch is at main, or no remote), fall back to `git diff HEAD` for staged changes.
+
+If there are still no git changes, review the most recently modified files mentioned in this conversation.
+
+## Phase 2: Launch Three Review Agents in Parallel
+
+Use the Agent tool to launch all three agents concurrently in a single message. Pass each agent the full diff so it has the complete context.
+
+### Agent 1: Code Reuse Review
+
+For each change:
+
+1. **Search for existing utilities and helpers** that could replace newly written code. Look for similar patterns elsewhere in the codebase — common locations are utility directories, shared modules, and files adjacent to the changed ones.
+2. **Flag any new function that duplicates existing functionality.** Suggest the existing function to use instead.
+3. **Flag any inline logic that could use an existing utility** — hand-rolled string manipulation, manual path handling, custom environment checks, ad-hoc type guards, and similar patterns are common candidates.
+
+### Agent 2: Code Quality Review
+
+Review the same changes for hacky patterns:
+
+1. **Redundant state**: state that duplicates existing state, cached values that could be derived, observers/effects that could be direct calls
+2. **Parameter sprawl**: adding new parameters to a function instead of generalizing or restructuring existing ones
+3. **Copy-paste with slight variation**: near-duplicate code blocks that should be unified with a shared abstraction
+4. **Leaky abstractions**: exposing internal details that should be encapsulated, or breaking existing abstraction boundaries
+5. **Stringly-typed code**: using raw strings where constants, enums (string unions), or branded types already exist in the codebase
+6. **Unnecessary JSX nesting**: wrapper Boxes/elements that add no layout value — check if inner component props already provide the needed behavior
+7. **Nested conditionals**: ternary chains, nested if/else, or nested switch 3+ levels deep — flatten with early returns, guard clauses, a lookup table, or an if/else-if cascade
+8. **Unnecessary comments**: comments explaining WHAT the code does, narrating the change, or referencing the task/caller — delete; keep only non-obvious WHY (hidden constraints, subtle invariants, workarounds)
+
+### Agent 3: Efficiency Review
+
+Review the same changes for efficiency:
+
+1. **Unnecessary work**: redundant computations, repeated file reads, duplicate network/API calls, N+1 patterns
+2. **Missed concurrency**: independent operations run sequentially when they could run in parallel
+3. **Hot-path bloat**: new blocking work added to startup or per-request/per-render hot paths
+4. **Recurring no-op updates**: state/store updates inside polling loops or event handlers that fire unconditionally
+5. **Unnecessary existence checks**: pre-checking file/resource existence before operating (TOCTOU anti-pattern) — operate directly and handle the error
+6. **Memory**: unbounded data structures, missing cleanup, event listener leaks
+7. **Overly broad operations**: reading entire files when only a portion is needed, loading all items when filtering for one
+
+## Phase 3: Fix Issues
+
+Wait for all three agents to complete. Aggregate their findings and fix each issue directly. If a finding is a false positive or not worth addressing, note it and move on.
+
+When done, briefly summarize what was fixed (or confirm the code was already clean).

--- a/.claude/skills/slice/SKILL.md
+++ b/.claude/skills/slice/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 ## Agent model
 
-Steps 1-2 and 4-8 run in the main conversation (interactive spec and review work). Step 3 dispatches ACs to `execution-agent` (defined in `.claude/agents/`), grouped by neighbourhood — ACs that touch the same files go in one call.
+Steps 1-2 and 4-10 run in the main conversation (interactive spec and review work). Step 3 dispatches ACs to `execution-agent` (defined in `.claude/agents/`), grouped by neighbourhood — ACs that touch the same files go in one call.
 
 ---
 
@@ -20,7 +20,7 @@ Steps 1-2 and 4-8 run in the main conversation (interactive spec and review work
 
 2. **Read the spec.** Open the linked spec file. Confirm the task and its ACs with the user BEFORE writing any code.
 
-3. **Resolve open decisions and implement.** Check the spec for an `## Open decisions` section or any language deferring implementation choices (e.g. "the executor should choose", "either approach works"). These are architectural forks that must be resolved before dispatching to the execution agent.
+3. **Resolve open decisions and implement.** Before dispatching any execution agent, capture the current HEAD: `git rev-parse HEAD`. Store this as `<baseline-sha>` — you'll need it for step 4. Then check the spec for an `## Open decisions` section or any language deferring implementation choices (e.g. "the executor should choose", "either approach works"). These are architectural forks that must be resolved before dispatching to the execution agent.
 
    For each unresolved decision:
    - Read the relevant source files to understand the current architecture
@@ -49,21 +49,23 @@ Steps 1-2 and 4-8 run in the main conversation (interactive spec and review work
    - If the agent reported assumptions or spec mismatches, decide whether to adjust the next batch's instructions, fix something, or ask the user
    - Verify commits exist and `pnpm check` passes before dispatching the next batch
 
-4. **Complete the spec's Done-when checklist.** Walk through every item in the spec's Done-when section (defined by the template — see `docs/specs/templates/change.md` or `bug.md`). Additionally:
+4. **Run `/review-changes <baseline-sha>..HEAD` on the implementation.** This reviews only the commits from this task. Apply any fixes and commit them before moving on. Skip for `[chore]` tasks only.
+
+6. **Complete the spec's Done-when checklist.** Walk through every item in the spec's Done-when section (defined by the template — see `docs/specs/templates/change.md` or `bug.md`). Additionally:
    - [ ] **File-size check.** Run `wc -l` on every source and test file touched during implementation. Compare against the thresholds defined in `docs/code-standards.md`. If any touched file is over the hard flag, pause before archiving and apply the test refactoring hierarchy — push pure-helper behaviour down to unit tests, decompose the source, extract fixtures. This is the checkpoint that catches implementation-time bloat; do NOT defer it to a future task.
    - [ ] **Remove** the handoff.md task entry entirely — handoff.md is a work queue, not a history. Do not mark it shipped, do not leave a link to the archive. Just delete the line. Update the "Current state" section (test count, layout changes) if needed.
    - [ ] If public surfaces changed, update the corresponding docs (the spec's Done-when checklist specifies which)
 
-5. **Archive the spec with reflection.** Move the spec file from `docs/specs/` to `docs/specs/archive/`. Append an `## Outcome` section with:
+7. **Archive the spec with reflection.** Move the spec file from `docs/specs/` to `docs/specs/archive/`. Append an `## Outcome` section with:
    - **Reflection:** What went well? What did not go well? What took longer than it should have? What would you recommend to the next agent picking up related work?
    - Actual test count added
    - Mutation score for touched files
    - Any architectural decisions or discoveries worth preserving
 
-   **Do NOT proceed to step 6 until the Outcome section — including the Reflection — is written in the archived spec file.**
+   **Do NOT proceed to step 8 until the Outcome section — including the Reflection — is written in the archived spec file.**
 
-6. **Capture any non-obvious gotchas** discovered during implementation. Put them in the relevant `docs/features/` or `docs/tech/` doc, or in `.claude/MEMORY.md` if cross-cutting. Add a code comment if the gotcha is visible at the call site.
+8. **Capture any non-obvious gotchas** discovered during implementation. Put them in the relevant `docs/features/` or `docs/tech/` doc, or in `.claude/MEMORY.md` if cross-cutting. Add a code comment if the gotcha is visible at the call site.
 
-7. **Commit** docs changes with a conventional commit message (see `CLAUDE.md`).
+9. **Commit** docs changes with a conventional commit message (see `CLAUDE.md`).
 
-8. Do NOT proceed to the next slice without explicit user approval.
+10. Do NOT proceed to the next slice without explicit user approval.


### PR DESCRIPTION
## Summary

- Adds `/review-changes` skill — accepts an optional commit range arg (`/review-changes abc123..HEAD`) so it works correctly after commits, not just on unstaged changes. Falls back to `git diff origin/main...HEAD` when no range is given. Runs three agents in parallel reviewing for reuse, quality, and efficiency.
- Wires `/review-changes <baseline>..HEAD` into the `/slice` workflow after all implementation batches complete.

## Test plan

- [ ] `/review-changes abc123..HEAD` diffs the specified range
- [ ] `/review-changes` with no arg falls back to branch diff

https://claude.ai/code/session_011w74HXsok7idwUabb83MxU