### PR TITLE
Add permissions to mutation testing workflow

### DIFF
--- a/.github/workflows/quality-feedback.yml
+++ b/.github/workflows/quality-feedback.yml
@@ -11,6 +11,9 @@ jobs:
     name: Mutation Testing
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
Updated the mutation testing workflow to explicitly declare required permissions for GitHub Actions.

## Key Changes
- Added `permissions` block to the mutation testing job with:
  - `id-token: write` - Allows the workflow to request OIDC tokens for authentication
  - `contents: write` - Allows the workflow to write to repository contents

## Details
These permissions enable the workflow to perform authenticated operations that may be required for mutation testing tools or subsequent steps that need to interact with the repository or external services using OIDC token-based authentication.

https://claude.ai/code/session_01Dy8KLGf4vUYUozYFzrcyiL