### PR TITLE
docs: reframe code standards around pre-edit assessment, not file size

### DIFF
--- a/.claude/agents/execution-agent.md
+++ b/.claude/agents/execution-agent.md
@@ -52,7 +52,7 @@ You receive **one or more ACs** from the orchestrator, grouped because they touc
 2. Read the spec file path and the ACs you've been given
 3. Read `CLAUDE.md` for project rules and `docs/code-standards.md` for coding standards — follow them exactly
 4. **Pre-implementation context:** Use `/implementation-context` — read 2-3 neighbouring files to absorb local patterns and find reusable code. Do this once per batch, not per AC.
-5. **Pre-implementation check:** Read the spec's `Relevant files` section and the target files you'll modify. Assess file sizes and complexity against the thresholds in `docs/code-standards.md`. If a target file is already near or over 300 lines, extract before extending.
+5. **Pre-implementation check:** Read the spec's `Relevant files` section and the target files you'll modify. For each file you'll extend, work through the assessment in `docs/code-standards.md` ("Before extending an existing file"). Refactor first if needed. Note your assessment in your agent notes.
 6. Address any `Red flags` from the spec — if the spec notes cleanup is needed first, do that before the feature work
 7. **For each AC in order:**
    a. Write failing tests FIRST (TDD)

--- a/.claude/skills/slice/SKILL.md
+++ b/.claude/skills/slice/SKILL.md
@@ -52,7 +52,7 @@ Steps 1-2 and 4-10 run in the main conversation (interactive spec and review wor
 4. **Run `/review-changes <baseline-sha>..HEAD` on the implementation.** This reviews only the commits from this task. Apply any fixes and commit them before moving on. Skip for `[chore]` tasks only.
 
 6. **Complete the spec's Done-when checklist.** Walk through every item in the spec's Done-when section (defined by the template — see `docs/specs/templates/change.md` or `bug.md`). Additionally:
-   - [ ] **File-size check.** Run `wc -l` on every source and test file touched during implementation. Compare against the thresholds defined in `docs/code-standards.md`. If any touched file is over the hard flag, pause before archiving and apply the test refactoring hierarchy — push pure-helper behaviour down to unit tests, decompose the source, extract fixtures. This is the checkpoint that catches implementation-time bloat; do NOT defer it to a future task.
+   - [ ] **Standards check.** For every file you extended, walk through `docs/code-standards.md`. Apply the refactoring hierarchy if needed. This is the checkpoint that catches implementation-time bloat; do NOT defer it to a future task.
    - [ ] **Remove** the handoff.md task entry entirely — handoff.md is a work queue, not a history. Do not mark it shipped, do not leave a link to the archive. Just delete the line. Update the "Current state" section (test count, layout changes) if needed.
    - [ ] If public surfaces changed, update the corresponding docs (the spec's Done-when checklist specifies which)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,8 @@ Skill files are interface documentation, not agent playbooks. Describe what the 
 **Rule 11: Pin exact dependency versions. Never use `^` or `~` ranges.**
 Ranges let a compromised patch release auto-install on the next `pnpm install`, turning a single package takeover into a supply-chain attack across every consumer. All versions in `package.json` must be exact (e.g. `"1.2.3"`, not `"^1.2.3"`). Only install actively maintained packages — check for deprecation warnings before adding a dependency.
 
-**Rule 13: Follow `docs/code-standards.md` for file size and reuse.**
-Read target files before extending them. Ideal file length is 150 lines; review at 300; hard flag at 500. Search for existing utilities before writing new ones. See `docs/code-standards.md` for the full set of refactoring triggers.
+**Rule 13: Assess existing files before extending them.**
+Before adding code, read the target file and apply the pre-edit assessment in `docs/code-standards.md`.
 
 **Rule 14: When fixing a bug, establish a failing state first.**
 Before applying a fix, confirm the failure with a reproducible command or a failing test. After applying the fix, verify that the same command or test now passes. Reading code and reasoning about why it should work is not verification.

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -2,15 +2,21 @@
 
 Project-wide coding standards. Referenced by agents, skills, and CLAUDE.md.
 
-These checks happen **before** implementing, not after. Read the target files, assess their size and complexity, and decide whether extraction or refactoring is needed before adding new code. This is cheaper and cleaner than untangling changes after the fact.
+These checks happen **before** implementing, not after. Read the target files, work through the assessment below, and decide whether extraction or refactoring is needed before adding new code. This is cheaper and cleaner than untangling changes after the fact.
 
-## File size
+## Before extending an existing file
 
-- **Ideal:** 150 lines or fewer. Small files are easy to test, review, and mutate.
-- **Review at 300:** Pause and consider whether the file has multiple responsibilities or contains logic that belongs in a utility.
-- **Hard flag at 500:** The file almost certainly needs decomposition. Do not extend it without extracting first.
+Read the file first. Then ask three questions:
 
-Large files make mutation testing expensive — more mutants per file means longer runs and harder triage.
+1. **Is my change a different responsibility from what's here?** If yes, the new code belongs somewhere else — a new file, an existing utility, a sibling module.
+2. **Is there code already in this file that should be extracted?** Generic logic, helpers usable elsewhere, anything not specific to this file's purpose. Pull it out before adding more.
+3. **Am I about to duplicate logic that exists elsewhere?** Search the codebase first. Extend or generalize a near-match rather than parallel-implementing.
+
+Do this *before* implementing — it's cheaper and cleaner than untangling afterwards. The "Refactoring triggers" section below lists the signals worth weighing during this assessment.
+
+**On file length specifically:** length is a signal that the questions above are worth asking, not a trigger to split. Around 300 lines, mixed responsibilities are common; over 500, almost always. Length alone never justifies a split.
+
+**Anti-pattern: splitting to hit a number.** Do not break a cohesive file into smaller files just because it crossed a length threshold. That trades one real cost (a long file) for several worse ones: more imports, harder navigation, scattered logic, and helpers that exist only because something had to be moved. If you can't name the distinct responsibility a new file would own, leave it alone.
 
 ## Reuse before create
 
@@ -39,9 +45,11 @@ Comments exist to provide context that cannot be gathered from names, types, and
 
 ## Tests
 
+Tests are production code. Everything above applies: read before extending, look for extraction opportunities, avoid duplicate setup, no comments restating assertions, no unreachable branches. The dimensions below cover what's *additional* to test code — not what replaces the standards above.
+
 ### Quality model
 
-Line count is one smell detector among several. A short test file can still be unhealthy. Assess test health on these dimensions:
+A short test file can still be unhealthy. Assess test health on these dimensions:
 
 - **Layer fit.** Is each test at the lowest layer that can verify the behaviour? Pure logic belongs at the unit layer with in-memory dependencies. Integration tests verify wiring, not exhaustive input variations.
 - **Setup proportionality.** Is the setup proportional to what's being verified? When the fixture ceremony dwarfs the assertion, the logic under test likely belongs behind a seam that can be tested with lighter dependencies.
@@ -59,7 +67,7 @@ Extracting a new entity (service, utility, domain object) changes the testing su
 
 ### Refactoring hierarchy
 
-The same file-size thresholds apply to test files. A large test file is usually a symptom — diagnose the cause before splitting. Work top to bottom:
+A large test file is usually a symptom — diagnose the cause before splitting. Work top to bottom:
 
 1. **Push integration tests down.** If an integration test is large because it exercises lots of internal logic, extract that logic into units with their own tests. Keep the integration test narrow — it should verify the integration point, not re-test the units.
 2. **Decompose the source.** If a unit test is large because the unit under test is complex, the source itself probably needs decomposition. Split the source; tests follow naturally.
@@ -75,7 +83,7 @@ Test doubles belong near the concept they mock, not in a generic folder. `makeMo
 
 Tests follow their subject. A test for an operation lives in the operation's test file; a test for an engine method lives in the engine's test file. If a test colocated with one subject is exercising another subject's logic indirectly, push it down to the right file.
 
-Size doesn't override this. When a test file approaches the 300-line review threshold, that triggers assessment via the refactoring hierarchy above — not a new test file as a workaround. A new test file is only justified after the hierarchy has been applied and the file still warrants splitting along feature boundaries.
+Size doesn't override this. When a test file grows large enough to give pause, that triggers assessment via the refactoring hierarchy above — not a new test file as a workaround. A new test file is only justified after the hierarchy has been applied and the file still warrants splitting along feature boundaries.
 
 ## Type casts
 


### PR DESCRIPTION
Replace the "File size" thresholds (150/300/500) with three questions
to ask before extending an existing file. Length becomes one signal
among several rather than the trigger. Lead the Tests section with
"tests are production code" so the same standards apply without
restating them. Remove duplicated guidance from CLAUDE.md, the
execution-agent, and the slice skill — they now point at the standard
instead of summarising it.

https://claude.ai/code/session_01NJ1DM9SAVmjyhWB9Aep6C8