### PR TITLE
chore: replace pnpm audit with Socket.dev; clean up stale overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,4 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm audit --prod --audit-level high
       - run: pnpm check

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
     "zod": "4.4.3"
   },
   "pnpm": {
+    "overrides": {
+      "fast-uri": "3.1.2"
+    },
     "ignoredBuiltDependencies": [
       "@playwright/browser-chromium",
       "@swc/core",

--- a/package.json
+++ b/package.json
@@ -72,12 +72,6 @@
     "zod": "4.4.3"
   },
   "pnpm": {
-    "overrides": {
-      "@hono/node-server": "2.0.1",
-      "express-rate-limit": "8.4.1",
-      "path-to-regexp": "8.4.2",
-      "picomatch": "4.0.4"
-    },
     "ignoredBuiltDependencies": [
       "@playwright/browser-chromium",
       "@swc/core",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri: 3.1.2
+
 importers:
 
   .:
@@ -2898,8 +2901,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -7512,7 +7515,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8122,7 +8125,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,12 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@hono/node-server': 2.0.1
-  express-rate-limit: 8.4.1
-  path-to-regexp: 8.4.2
-  picomatch: 4.0.4
-
 importers:
 
   .:
@@ -874,9 +868,9 @@ packages:
     resolution: {integrity: sha512-XTYObncN5Rqexc0uITZIN9OWTEyE/ZR2S6c7wAniqHe2oGXW9gcHR9f9hQwPMHFUTHjH7Jkj8SLdt0O0u37y2A==}
     engines: {node: '>=12.0.0'}
 
-  '@hono/node-server@2.0.1':
-    resolution: {integrity: sha512-jI9yMDyFpqBeSighf/zlXnQG/nl9AyBc6aAgy4XtxJMyt/CNyJpvPfzDD+bCc2zAOmhhqtF6TnmIaY+xV4mIrw==}
-    engines: {node: '>=20'}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
 
@@ -2925,7 +2919,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: 4.0.4
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -6034,7 +6028,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@hono/node-server@2.0.1(hono@4.12.7)':
+  '@hono/node-server@1.19.14(hono@4.12.7)':
     dependencies:
       hono: 4.12.7
 
@@ -6332,7 +6326,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.1(hono@4.12.7)
+      '@hono/node-server': 1.19.14(hono@4.12.7)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5


### PR DESCRIPTION
## Summary

- Remove `pnpm audit --prod --audit-level high` from CI — it was blocking unrelated dependency PRs due to pre-existing transitive vulnerabilities it couldn't fix. Socket.dev now covers supply-chain scanning on PRs.
- Remove four stale `pnpm.overrides` (`@hono/node-server`, `express-rate-limit`, `path-to-regexp`, `picomatch`) — verified each one no longer prevents any audit failures; upstreams have patched.
- Add `fast-uri: 3.1.2` override to fix two high-severity prod vulnerabilities (path traversal + host confusion) in the `@modelcontextprotocol/sdk → ajv → fast-uri` chain. After this, `pnpm audit --prod` reports zero high/critical findings.

## Test plan

- [ ] CI passes without the audit step
- [ ] `pnpm audit --prod --audit-level high` returns zero findings locally

https://claude.ai/code/session_01JGYr98YafNM6aJF3AoenDz

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGYr98YafNM6aJF3AoenDz)_