### PR TITLE
Fix daemon process cleanup to prevent parent event loop hang

### DIFF
--- a/src/daemon/ensure-daemon.test.ts
+++ b/src/daemon/ensure-daemon.test.ts
@@ -69,10 +69,12 @@ function closeServer(server: net.Server): Promise<void> {
  * opts.ready=true (default): emits { status: "ready" } on stderr after a tick.
  * opts.exitCode: emits "exit" instead (simulates daemon crash before ready).
  */
+type FakeStderr = EventEmitter & { destroy: ReturnType<typeof vi.fn> };
+
 function makeFakeChild(opts: { ready?: boolean; exitCode?: number } = { ready: true }) {
-  const stderr = new EventEmitter();
+  const stderr = Object.assign(new EventEmitter(), { destroy: vi.fn() }) as FakeStderr;
   const child = new EventEmitter() as EventEmitter & {
-    stderr: EventEmitter;
+    stderr: FakeStderr;
     unref: ReturnType<typeof vi.fn>;
   };
   child.stderr = stderr;
@@ -237,9 +239,9 @@ describe("ensureDaemon", () => {
     it("rejects rather than resolving on a non-ready stderr line before crash", async () => {
       mockIsDaemonAlive.mockReturnValue(false);
 
-      const stderr = new EventEmitter();
+      const stderr = Object.assign(new EventEmitter(), { destroy: vi.fn() });
       const child = new EventEmitter() as EventEmitter & {
-        stderr: EventEmitter;
+        stderr: typeof stderr;
         unref: ReturnType<typeof vi.fn>;
       };
       child.stderr = stderr;
@@ -251,6 +253,18 @@ describe("ensureDaemon", () => {
       mockSpawn.mockImplementation(() => child);
 
       await expect(ensureDaemon(WORKSPACE)).rejects.toThrow(/exited unexpectedly/i);
+    });
+
+    it("detaches the child's stderr pipe and exit listener so the parent can exit", async () => {
+      mockIsDaemonAlive.mockReturnValue(false);
+      const child = makeFakeChild({ ready: true });
+      mockSpawn.mockReturnValue(child);
+
+      await ensureDaemon(WORKSPACE);
+
+      expect(child.stderr.destroy).toHaveBeenCalled();
+      expect(child.unref).toHaveBeenCalled();
+      expect(child.listenerCount("exit")).toBe(0);
     });
 
     it("skips ping on the next call after a successful spawn", async () => {

--- a/src/daemon/ensure-daemon.test.ts
+++ b/src/daemon/ensure-daemon.test.ts
@@ -69,22 +69,23 @@ function closeServer(server: net.Server): Promise<void> {
  * opts.ready=true (default): emits { status: "ready" } on stderr after a tick.
  * opts.exitCode: emits "exit" instead (simulates daemon crash before ready).
  */
-type FakeStderr = EventEmitter & { destroy: ReturnType<typeof vi.fn> };
+class FakeStderr extends EventEmitter {
+  destroy = vi.fn();
+}
+
+class FakeChild extends EventEmitter {
+  stderr = new FakeStderr();
+  unref = vi.fn();
+}
 
 function makeFakeChild(opts: { ready?: boolean; exitCode?: number } = { ready: true }) {
-  const stderr = Object.assign(new EventEmitter(), { destroy: vi.fn() }) as FakeStderr;
-  const child = new EventEmitter() as EventEmitter & {
-    stderr: FakeStderr;
-    unref: ReturnType<typeof vi.fn>;
-  };
-  child.stderr = stderr;
-  child.unref = vi.fn();
+  const child = new FakeChild();
 
   if (opts.exitCode !== undefined) {
     setTimeout(() => child.emit("exit", opts.exitCode), 0);
   } else if (opts.ready !== false) {
     setTimeout(
-      () => stderr.emit("data", Buffer.from(`${JSON.stringify({ status: "ready" })}\n`)),
+      () => child.stderr.emit("data", Buffer.from(`${JSON.stringify({ status: "ready" })}\n`)),
       0,
     );
   }
@@ -239,15 +240,9 @@ describe("ensureDaemon", () => {
     it("rejects rather than resolving on a non-ready stderr line before crash", async () => {
       mockIsDaemonAlive.mockReturnValue(false);
 
-      const stderr = Object.assign(new EventEmitter(), { destroy: vi.fn() });
-      const child = new EventEmitter() as EventEmitter & {
-        stderr: typeof stderr;
-        unref: ReturnType<typeof vi.fn>;
-      };
-      child.stderr = stderr;
-      child.unref = vi.fn();
+      const child = new FakeChild();
       setTimeout(() => {
-        stderr.emit("data", Buffer.from(`${JSON.stringify({ status: "starting" })}\n`));
+        child.stderr.emit("data", Buffer.from(`${JSON.stringify({ status: "starting" })}\n`));
         child.emit("exit", 1);
       }, 0);
       mockSpawn.mockImplementation(() => child);

--- a/src/daemon/ensure-daemon.ts
+++ b/src/daemon/ensure-daemon.ts
@@ -115,6 +115,11 @@ function spawnDaemon(absWorkspace: string, opts: { verbose?: boolean } = {}): Pr
       reject(new Error("Timed out waiting for daemon ready signal"));
     }, 30_000);
 
+    const onExit = (code: number | null) => {
+      clearTimeout(timer);
+      reject(new Error(`Daemon exited unexpectedly with code ${code}`));
+    };
+
     const onData = (chunk: Buffer) => {
       stderrBuf += chunk.toString();
       while (stderrBuf.indexOf("\n", consumed) !== -1) {
@@ -126,6 +131,10 @@ function spawnDaemon(absWorkspace: string, opts: { verbose?: boolean } = {}): Pr
           if (msg.status === "ready") {
             clearTimeout(timer);
             child.stderr.off("data", onData);
+            child.off("exit", onExit);
+            // The piped stderr is a separate handle from the child process;
+            // unref() alone leaves it active and hangs the parent's event loop.
+            child.stderr.destroy();
             child.unref();
             resolve();
             return;
@@ -137,10 +146,6 @@ function spawnDaemon(absWorkspace: string, opts: { verbose?: boolean } = {}): Pr
     };
 
     child.stderr.on("data", onData);
-
-    child.on("exit", (code) => {
-      clearTimeout(timer);
-      reject(new Error(`Daemon exited unexpectedly with code ${code}`));
-    });
+    child.on("exit", onExit);
   });
 }


### PR DESCRIPTION
## Summary
The daemon spawning logic was leaving the child process's stderr pipe active after the daemon became ready, preventing the parent process from exiting cleanly. This change ensures all handles are properly detached and destroyed.

## Changes
- **Extract exit handler**: Moved the child process exit listener into a named `onExit` function so it can be properly removed when the daemon becomes ready
- **Destroy stderr pipe**: Call `child.stderr.destroy()` after the ready signal is received to close the piped stderr handle, which is a separate event loop handle from the child process itself
- **Remove exit listener**: Call `child.off("exit", onExit)` to detach the exit handler when ready, preventing unnecessary error handling after successful startup
- **Update test types**: Added `FakeStderr` type to properly mock the `destroy` method on stderr in test fixtures
- **Add cleanup verification test**: New test confirms that both `stderr.destroy()` and `child.unref()` are called, and that the exit listener is removed (listener count is 0)

## Implementation Details
The issue was that `child.unref()` alone is insufficient—it only unrefs the child process handle itself. The piped stderr stream is a separate handle that remains active in the event loop. Calling `destroy()` on it closes that handle and allows the parent process to exit when there are no other pending operations.

The exit listener is now removed explicitly to avoid holding a reference to the rejection handler after the daemon is confirmed ready.

https://claude.ai/code/session_019GPWqNadZntDvPPagbE2Rv