### PR TITLE
build: upgrade to pnpm 11 (single-sourced version)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: 10.33.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/quality-feedback.yml
+++ b/.github/workflows/quality-feedback.yml
@@ -18,8 +18,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: 10.33.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,8 +29,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: 10.33.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-exact=true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yearofthedan/weaver",
   "version": "0.1.5",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.5.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/yearofthedan/weaver.git"
@@ -37,7 +37,7 @@
   },
   "engines": {
     "node": ">=22",
-    "pnpm": ">=10"
+    "pnpm": ">=11"
   },
   "scripts": {
     "build": "rm -rf dist && tsc && chmod +x dist/adapters/cli/cli.js",
@@ -70,19 +70,6 @@
     "ts-morph": "28.0.0",
     "typescript": "6.0.3",
     "zod": "4.4.3"
-  },
-  "pnpm": {
-    "ignoredBuiltDependencies": [
-      "@playwright/browser-chromium",
-      "@swc/core",
-      "esbuild",
-      "onnxruntime-node",
-      "protobufjs",
-      "sharp"
-    ],
-    "onlyBuiltDependencies": [
-      "better-sqlite3"
-    ]
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+# pnpm 11 reads non-auth settings from here, not .npmrc or package.json#pnpm.
+savePrefix: '' # pin exact versions on `pnpm add` — no auto-updating range prefixes
+allowBuilds:
+  esbuild: false # platform binary comes from optional deps; no build step needed


### PR DESCRIPTION
Upgrades the repo to **pnpm 11.5.2** and fixes the version-source drift that was breaking Renovate's pnpm PRs. Supersedes #162 and #163.

## Why Renovate's pnpm PRs failed

pnpm was pinned in two places that must agree — `packageManager` in `package.json` and a hard-coded `version:` on `pnpm/action-setup` in three workflows. Renovate only bumps `packageManager` (the `github-actions` manager isn't enabled), so every pnpm bump tripped `ERR_PNPM_BAD_PM_VERSION` at setup.

## Changes

**Single-source the version**
- Drop the `version:` key from `ci.yml`, `release-please.yml`, `quality-feedback.yml`. `pnpm/action-setup` now reads pnpm from `packageManager`.

**Upgrade to pnpm 11** (breaking changes handled)
- pnpm 11 no longer reads the `pnpm` field in `package.json` or non-auth settings from `.npmrc`; both move to `pnpm-workspace.yaml`.
- `onlyBuiltDependencies`/`ignoredBuiltDependencies` are replaced by the `allowBuilds` map; `strictDepBuilds` now defaults to `true`.
- `packageManager` → `pnpm@11.5.2`, `engines.pnpm` → `>=11`.
- `save-exact` (`.npmrc`) → `savePrefix: ''` in `pnpm-workspace.yaml`; `.npmrc` deleted.
- Build allowlist → `allowBuilds: { esbuild: false }`. The other six entries (sharp, onnxruntime-node, @swc/core, @playwright/browser-chromium, protobufjs, better-sqlite3) were promptfoo's native deps and are no longer in the tree.

## Verification

- `pnpm install` under 11.5.2: lockfile (v9.0) already compatible, no resolution needed, passes supply-chain policy. `strictDepBuilds` passes (esbuild ignore respected).
- `pnpm check` green under 11.5.2: Biome clean, build OK, 1024 tests + 134 eval pass.
- `renovate.json` needs no change: the `engines` rule keeps `engines.pnpm` a loose `>=` range, so the bump won't get pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)