### PR TITLE
build(devcontainer): provision pnpm via corepack

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,9 +11,6 @@
     "ghcr.io/devcontainers/features/github-cli:1": {
       "version": "2.90.0"
     },
-    "ghcr.io/devcontainers-extra/features/pnpm:2": {
-      "version": "10.33.0"
-    },
     "ghcr.io/devcontainer-community/devcontainer-features/lazygit:1": {
       "version": "0.61.0"
     },

--- a/.devcontainer/onCreate.sh
+++ b/.devcontainer/onCreate.sh
@@ -10,6 +10,11 @@ echo "🔑 Fixing workspace permissions..."
 sudo chown -R node:node .
 sudo chown -R node:node /home/node/.vscode-server 2>/dev/null || true
 
+# 📦 pnpm comes from corepack, pinned by packageManager in package.json —
+# no separate devcontainer feature to keep in sync.
+echo "📦 Enabling corepack for pnpm..."
+sudo corepack enable pnpm
+
 # ⬇️ Pull the repo
 if [ ! -d ".git" ]; then
     git init


### PR DESCRIPTION
Follow-up to #166. Removes the last duplicate pnpm-version source.

## Why

The devcontainer pinned pnpm through `ghcr.io/devcontainers-extra/features/pnpm:2` at `10.33.0` — a third place the version lived, alongside `packageManager` and (before #166) the CI workflows. Renovate bumps this feature on its own `devcontainer`-manager cadence, separate from the `packageManager` bump, so the two drift apart transiently — the same class of mismatch that broke CI.

## Change

- Remove the `features/pnpm:2` feature.
- `corepack enable pnpm` in `onCreate.sh` (runs before `postCreateCommand: pnpm install`), so pnpm is provisioned from `packageManager` in `package.json`. The base image (`javascript-node:24`) already ships corepack.

`packageManager` is now the single source of truth across CI, devcontainer, and local.

## Note

Depends on #166 (which sets `packageManager` to `pnpm@11.5.2`); branched off it, so the diff against `main` will show those commits until #166 merges. The devcontainer build isn't exercised by CI, so this is verified by inspection, not a green check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)