### PR TITLE
fix(test): scrub leaked git env so the suite is hermetic

### DIFF
--- a/src/__testHelpers__/test-cleanup.ts
+++ b/src/__testHelpers__/test-cleanup.ts
@@ -2,6 +2,35 @@ import { afterEach } from "vitest";
 import { invalidateAll } from "../daemon/language-plugin-registry.js";
 
 /**
+ * Make the test process hermetic against an inherited git environment.
+ *
+ * Several suites shell out to `git` inside throwaway temp directories. When the
+ * test run is launched from a git hook (e.g. husky pre-commit running
+ * `pnpm check`), git exports repo-discovery variables — `GIT_DIR`,
+ * `GIT_INDEX_FILE`, … — into the environment. A child `git` started with a
+ * `cwd` then ignores that `cwd` and operates on the host repository instead.
+ * On a normal checkout the leaked `GIT_DIR` is the relative `.git`, so it
+ * harmlessly fails to resolve from a temp dir; in a linked worktree git
+ * exports an absolute path, so the temp-dir `git add`/`git commit` calls write
+ * straight into the real repo and corrupt it. Stripping these forces every
+ * spawned `git` to discover its repository from `cwd` alone. In a normal run
+ * none of these are set, so this is a no-op.
+ */
+for (const key of [
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_COMMON_DIR",
+  "GIT_PREFIX",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_NAMESPACE",
+  "GIT_CEILING_DIRECTORIES",
+]) {
+  delete process.env[key];
+}
+
+/**
  * Global test cleanup: dispose of cached engines after each test.
  * Prevents memory leaks from accumulated Project instances in TsMorphEngine.
  */


### PR DESCRIPTION
## Problem

Committing from a **linked git worktree** corrupted the repository: stray `init` commits appeared and the tracked tree was replaced with a test fixture (`a.ts`/`b.ts`).

## Root cause

The `file-walk` and `move-file` test suites shell out to `git` inside throwaway temp dirs. When the suite runs from a git hook (husky `pre-commit` → `pnpm check`), git exports its repo-discovery vars (`GIT_DIR`, `GIT_INDEX_FILE`, …) into the environment. A child `git` started with a `cwd` then **ignores that `cwd`** and operates on the host repo instead:

- **Normal checkout:** the leaked `GIT_DIR` is the relative `.git`, which fails to resolve from a temp dir → git falls back correctly → harmless. (This is why it never bit on `main`.)
- **Linked worktree:** git exports an **absolute** `GIT_DIR`, so the temp-dir `git add`/`git commit` calls write straight into the real worktree repo → corruption.

## Fix

Strip git's repo-discovery vars in the global test setup (`test-cleanup.ts`, already wired via vitest `setupFiles`), so every spawned `git` discovers its repo from `cwd` alone. **No production code changes** — the bug is in the test harness, so the fix lives there. In a normal run none of these vars are set, so it's a no-op.

## Verification (Rule 14: failing state first)

Pointed `GIT_DIR`/`GIT_WORK_TREE` at a throwaway repo and ran the `file-walk` suite:

- **Without the scrub:** 28 / 32 tests fail.
- **With the scrub:** all 32 pass; throwaway repo untouched.

And this PR's own commit was made **with the hook enabled, from a worktree** — the exact action that previously corrupted the repo — and completed cleanly (`pnpm check` green inside pre-commit, 1024 tests passed, no stray commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)